### PR TITLE
step-900/910: content source-of-truth contract baseline

### DIFF
--- a/blog/welcome.md
+++ b/blog/welcome.md
@@ -1,0 +1,11 @@
+---
+title: "Welcome to Kriegspiel.org"
+slug: "welcome"
+summary: "Launch notes for the website track."
+publishedAt: "2026-03-27"
+updatedAt: "2026-03-27"
+author: "Kriegspiel Team"
+tags: ["website", "announcement"]
+draft: false
+---
+Initial website-track content contract post.

--- a/changelog/2026-03-27-ia-contracts.md
+++ b/changelog/2026-03-27-ia-contracts.md
@@ -1,0 +1,12 @@
+---
+title: "Slice 910 foundations locked"
+slug: "2026-03-27-slice-910"
+summary: "IA, route contracts, and content schema baseline published."
+publishedAt: "2026-03-27"
+updatedAt: "2026-03-27"
+author: "Kriegspiel Team"
+tags: ["changelog", "step-900"]
+draft: false
+version: "0.9.10"
+---
+Completed Slice 910 contract baseline.

--- a/docs/content-source-contract.md
+++ b/docs/content-source-contract.md
@@ -1,0 +1,28 @@
+# Content Source Contract (Slice 910)
+
+Kriegspiel/content is the source of truth for website collections consumed by ks-home.
+
+## Collections
+
+- blog/ -> blog index + /blog/:slug
+- changelog/ -> changelog index + /changelog/:slug
+- rules/ -> rules index and rule details
+
+## Required frontmatter
+
+- title
+- slug
+- summary
+- publishedAt
+- updatedAt
+- author
+- tags
+- draft
+- version (required for changelog and rules)
+
+## Contract checks
+
+Validated from ks-home via:
+
+- npm run content:schema:check
+- npm run content:source-contract:check

--- a/rules/berkeley.md
+++ b/rules/berkeley.md
@@ -1,3 +1,14 @@
+---
+title: "Berkeley Kriegspiel Rules"
+slug: "berkeley"
+summary: "Berkeley variant ruleset and referee announcement semantics."
+publishedAt: "2026-03-27"
+updatedAt: "2026-03-27"
+author: "Kriegspiel Team"
+tags: ["rules", "berkeley"]
+draft: false
+version: "1.0.0"
+---
 > *from [w01lfe's Berkeley rules](http://w01fe.com/berkeley/kriegspiel/rules.html)*
 
 # Kriegspiel Rules

--- a/rules/wild_16.md
+++ b/rules/wild_16.md
@@ -1,3 +1,14 @@
+---
+title: "Wild 16 Kriegspiel Rules"
+slug: "wild-16"
+summary: "Wild 16 announcement and move validation pattern."
+publishedAt: "2026-03-27"
+updatedAt: "2026-03-27"
+author: "Kriegspiel Team"
+tags: ["rules", "wild-16"]
+draft: false
+version: "1.0.0"
+---
 > *from [ICC Help](https://www.chessclub.com/user/help/Kriegspiel)*
 
 The computer referee makes the following announcements where appropriate:


### PR DESCRIPTION
Slice 910 scope: content-repo contract baseline.

What changed:
- Added blog collection with frontmatter example.
- Added changelog collection with versioned entry.
- Added docs/content-source-contract.md for ks-home consumers.
- Added required frontmatter blocks to rules documents.

Acceptance mapping:
- Content source contract documented: docs/content-source-contract.md
- Required frontmatter schema present across blog/changelog/rules
- Foundation for content-driven static generation is available to ks-home