### PR TITLE
Slice 930: editorial pipeline checks

### DIFF
--- a/docs/editorial-pipeline.md
+++ b/docs/editorial-pipeline.md
@@ -1,0 +1,26 @@
+# Editorial Pipeline (Slice 930)
+
+## Authoring Conventions
+- Write posts in `blog/*.md` and release entries in `changelog/*.md`.
+- Required frontmatter: `title`, `slug`, `summary`, `publishedAt`, `updatedAt`, `author`, `tags`, `draft`.
+- Changelog additionally requires `version`.
+- Keep `draft: true` for preview-only content.
+
+## Local Validation
+```bash
+npm ci
+npm run lint:markdown
+npm run lint:links
+npm run validate:frontmatter
+npm run build:content-index
+```
+
+## Preview Flow
+- `ks-home` supports draft preview with `KS_PREVIEW_DRAFTS=true npm run build`.
+- Production build excludes drafts by default.
+
+## Publishing Checklist
+1. Run all content checks above.
+2. Verify slug uniqueness.
+3. Link to related changelog/blog entry when relevant.
+4. Merge content PR; website regeneration check must pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "kriegspiel-content",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kriegspiel-content",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "kriegspiel-content",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "lint:markdown": "node scripts/lint-markdown.mjs",
+    "lint:links": "node scripts/lint-links.mjs",
+    "validate:frontmatter": "node scripts/validate-frontmatter.mjs",
+    "build:content-index": "node scripts/build-content-index.mjs"
+  }
+}

--- a/scripts/build-content-index.mjs
+++ b/scripts/build-content-index.mjs
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import path from "node:path";
+import { listMarkdown, parseFrontmatter } from "./lib.mjs";
+
+const entries = listMarkdown().map((doc) => {
+  const { metadata } = parseFrontmatter(doc.raw);
+  return {
+    collection: doc.dir,
+    file: doc.file,
+    title: metadata.title,
+    slug: metadata.slug,
+    summary: metadata.summary,
+    publishedAt: metadata.publishedAt,
+    updatedAt: metadata.updatedAt,
+    author: metadata.author,
+    tags: metadata.tags,
+    draft: metadata.draft,
+    version: metadata.version || null,
+    path: `/${doc.dir}/${metadata.slug}`
+  };
+}).sort((a, b) => String(b.publishedAt).localeCompare(String(a.publishedAt)));
+
+const out = path.join(process.cwd(), "dist/content-index.json");
+fs.mkdirSync(path.dirname(out), { recursive: true });
+fs.writeFileSync(out, JSON.stringify({ generatedAt: new Date().toISOString(), entries }, null, 2) + "\n", "utf8");
+console.log(`content index built: ${entries.length} entries`);

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const REQUIRED = ["title", "slug", "summary", "publishedAt", "updatedAt", "author", "tags", "draft"];
+
+export function listMarkdown(root = process.cwd()) {
+  return ["blog", "changelog"].flatMap((dir) => {
+    const full = path.join(root, dir);
+    if (!fs.existsSync(full)) return [];
+    return fs.readdirSync(full).filter((f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md").map((file) => ({ dir, file, fullPath: path.join(full, file), raw: fs.readFileSync(path.join(full, file), "utf8") }));
+  });
+}
+
+export function parseFrontmatter(raw) {
+  const lines = raw.split(/\r?\n/);
+  if (lines[0] !== "---") return { metadata: {}, body: raw };
+  const metadata = {};
+  let idx = 1;
+  for (; idx < lines.length; idx += 1) {
+    const line = lines[idx];
+    if (line === "---") { idx += 1; break; }
+    const sep = line.indexOf(":");
+    if (sep < 1) continue;
+    const key = line.slice(0, sep).trim();
+    const val = line.slice(sep + 1).trim();
+    metadata[key] = parseValue(val);
+  }
+  return { metadata, body: lines.slice(idx).join("\n") };
+}
+
+function parseValue(value) {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (value.startsWith("[") && value.endsWith("]")) {
+    const inner = value.slice(1, -1).trim();
+    return inner ? inner.split(",").map((x) => x.trim().replace(/^"|"$/g, "")) : [];
+  }
+  return value.replace(/^"|"$/g, "");
+}

--- a/scripts/lint-links.mjs
+++ b/scripts/lint-links.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { listMarkdown } from "./lib.mjs";
+
+const issues = [];
+const pattern = /\[[^\]]+\]\(([^)]+)\)/g;
+for (const doc of listMarkdown()) {
+  for (const match of doc.raw.matchAll(pattern)) {
+    const href = match[1];
+    if (/^https?:\/\//.test(href) || href.startsWith("mailto:")) continue;
+    const target = path.resolve(path.dirname(doc.fullPath), href);
+    if (!fs.existsSync(target)) issues.push(`${doc.dir}/${doc.file}: broken relative link ${href}`);
+  }
+}
+assert.equal(issues.length, 0, issues.join("\n"));
+console.log("link lint ok");

--- a/scripts/lint-markdown.mjs
+++ b/scripts/lint-markdown.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { listMarkdown } from "./lib.mjs";
+
+const issues = [];
+for (const doc of listMarkdown()) {
+  const lines = doc.raw.split(/\r?\n/);
+  if (lines[0] !== "---") issues.push(`${doc.dir}/${doc.file}: missing frontmatter start`);
+  if (!doc.raw.includes("\n---\n")) issues.push(`${doc.dir}/${doc.file}: missing frontmatter end`);
+  if (/\t/.test(doc.raw)) issues.push(`${doc.dir}/${doc.file}: contains tab characters`);
+}
+assert.equal(issues.length, 0, issues.join("\n"));
+console.log(`markdown lint ok: ${listMarkdown().length} files`);

--- a/scripts/validate-frontmatter.mjs
+++ b/scripts/validate-frontmatter.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { REQUIRED, listMarkdown, parseFrontmatter } from "./lib.mjs";
+
+const issues = [];
+const slugSeen = new Set();
+for (const doc of listMarkdown()) {
+  const { metadata } = parseFrontmatter(doc.raw);
+  for (const field of REQUIRED) if (!(field in metadata)) issues.push(`${doc.dir}/${doc.file}: missing ${field}`);
+  if (doc.dir === "changelog" && !("version" in metadata)) issues.push(`${doc.dir}/${doc.file}: missing version`);
+  if (metadata.tags && !Array.isArray(metadata.tags)) issues.push(`${doc.dir}/${doc.file}: tags must be array`);
+  if (metadata.publishedAt && Number.isNaN(Date.parse(metadata.publishedAt))) issues.push(`${doc.dir}/${doc.file}: invalid publishedAt`);
+  if (metadata.updatedAt && Number.isNaN(Date.parse(metadata.updatedAt))) issues.push(`${doc.dir}/${doc.file}: invalid updatedAt`);
+  if (metadata.slug) {
+    const key = `${doc.dir}:${metadata.slug}`;
+    if (slugSeen.has(key)) issues.push(`${doc.dir}/${doc.file}: duplicate slug ${metadata.slug}`);
+    slugSeen.add(key);
+  }
+}
+assert.equal(issues.length, 0, issues.join("\n"));
+console.log("frontmatter validation ok");


### PR DESCRIPTION
Implements slice 930 content-side editorial pipeline:\n- markdown/link/frontmatter lint scripts\n- content index build\n- draft/authoring docs\n\nValidation run:\n- npm ci\n- npm run lint:markdown\n- npm run lint:links\n- npm run validate:frontmatter\n- npm run build:content-index