### PR TITLE
step-900/940: rules revision metadata + changelog linkage

### DIFF
--- a/changelog/2026-03-27-slice-940-trust-discoverability.md
+++ b/changelog/2026-03-27-slice-940-trust-discoverability.md
@@ -1,0 +1,18 @@
+---
+title: Slice 940 trust and discoverability baseline
+slug: 2026-03-27-slice-940-trust-discoverability
+summary: Published rules revisions, SEO/structured-data baseline, analytics privacy contract, and legal pages.
+publishedAt: 2026-03-27
+updatedAt: 2026-03-27
+author: Kriegspiel Team
+tags: [changelog, step-900, seo, legal, analytics]
+draft: false
+version: 0.9.40
+---
+Completed Step 900 Slice 940.
+
+Highlights:
+- Rules pages now publish revision IDs and changelog linkage.
+- Route-level SEO metadata and JSON-LD structured data are emitted on core routes.
+- Analytics event catalog is constrained by a no-PII contract and tested.
+- Privacy and Terms pages are now first-class public routes.

--- a/rules/berkeley.md
+++ b/rules/berkeley.md
@@ -8,6 +8,9 @@ author: "Kriegspiel Team"
 tags: ["rules", "berkeley"]
 draft: false
 version: "1.0.0"
+revision: "rules-berkeley-r1"
+lastReviewedAt: "2026-03-27"
+changelogSlug: "2026-03-27-slice-940-trust-discoverability"
 ---
 > *from [w01lfe's Berkeley rules](http://w01fe.com/berkeley/kriegspiel/rules.html)*
 

--- a/rules/wild_16.md
+++ b/rules/wild_16.md
@@ -8,6 +8,9 @@ author: "Kriegspiel Team"
 tags: ["rules", "wild-16"]
 draft: false
 version: "1.0.0"
+revision: "rules-wild16-r1"
+lastReviewedAt: "2026-03-27"
+changelogSlug: "2026-03-27-slice-940-trust-discoverability"
 ---
 > *from [ICC Help](https://www.chessclub.com/user/help/Kriegspiel)*
 


### PR DESCRIPTION
Implements Slice 940 content requirements:\n- Adds revision/lastReviewed/changelog linkage metadata to rules entries\n- Adds changelog entry for trust/discoverability rollout