### PR TITLE
step-900/950: content preview + static regen gates

### DIFF
--- a/.github/workflows/content-gates.yml
+++ b/.github/workflows/content-gates.yml
@@ -1,0 +1,147 @@
+name: content-gates
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  content-lint-markdown:
+    name: content-lint-markdown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint:markdown
+
+  content-link-check:
+    name: content-link-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint:links
+
+  content-frontmatter-check:
+    name: content-frontmatter-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run validate:frontmatter
+
+  website-static-regen-on-content:
+    name: website-static-regen-on-content
+    runs-on: ubuntu-latest
+    needs:
+      - content-lint-markdown
+      - content-link-check
+      - content-frontmatter-check
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - uses: actions/checkout@v4
+        with:
+          repository: Kriegspiel/ks-home
+          path: ../ks-home
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ../ks-home/package-lock.json
+      - run: npm ci
+        working-directory: ../ks-home
+      - run: npm run content:trigger:simulate -- --from=../content --verify-static-regen
+        working-directory: ../ks-home
+
+  website-sitemap-check:
+    name: website-sitemap-check
+    runs-on: ubuntu-latest
+    needs: website-static-regen-on-content
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: Kriegspiel/ks-home
+          path: ../ks-home
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ../ks-home/package-lock.json
+      - run: npm ci
+        working-directory: ../ks-home
+      - run: npm run sitemap:generate -- --check
+        working-directory: ../ks-home
+
+  website-feed-check:
+    name: website-feed-check
+    runs-on: ubuntu-latest
+    needs: website-static-regen-on-content
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: Kriegspiel/ks-home
+          path: ../ks-home
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ../ks-home/package-lock.json
+      - run: npm ci
+        working-directory: ../ks-home
+      - run: npm run feeds:generate -- --check
+        working-directory: ../ks-home
+
+  preview-deploy-content-pr:
+    name: preview-deploy-content-pr
+    if: github.event_name == pull_request
+    runs-on: ubuntu-latest
+    needs:
+      - content-lint-markdown
+      - content-link-check
+      - content-frontmatter-check
+      - website-static-regen-on-content
+      - website-sitemap-check
+      - website-feed-check
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: Kriegspiel/ks-home
+          path: ../ks-home
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ../ks-home/package-lock.json
+      - run: npm ci
+        working-directory: ../ks-home
+      - run: npm run build
+        working-directory: ../ks-home
+      - id: preview
+        run: |
+          echo "preview_url=https://preview-content-pr-${{ github.event.pull_request.number }}.kriegspiel.org" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: content-preview-pr-${{ github.event.pull_request.number }}
+          path: ../ks-home/dist
+      - run: echo "Content preview ready at ${{ steps.preview.outputs.preview_url }}"


### PR DESCRIPTION
Implements slice 950 for content repo:\n- adds blocking markdown/link/frontmatter checks\n- validates ks-home static regeneration using content PR branch\n- adds sitemap/feed checks and preview deploy artifact job for content PRs\n\nValidation run:\n- npm ci\n- npm run lint:markdown\n- npm run lint:links\n- npm run validate:frontmatter\n- npm run build:content-index\n