### PR TITLE
feat: enforce content repo policy hygiene

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Kriegspiel content ownership
+* @Fillll @lgyanf
+
+/blog/ @Fillll @lgyanf
+/changelog/ @Fillll @lgyanf
+/rules/ @Fillll @lgyanf
+/docs/ @Fillll @lgyanf
+/scripts/ @Fillll @lgyanf
+/.github/ @Fillll @lgyanf

--- a/.github/workflows/content-gates.yml
+++ b/.github/workflows/content-gates.yml
@@ -7,6 +7,18 @@ on:
     branches: [master]
 
 jobs:
+  content-policy-check:
+    name: content-policy-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run validate:content-policy
+
   content-lint-markdown:
     name: content-lint-markdown
     runs-on: ubuntu-latest
@@ -50,6 +62,7 @@ jobs:
       - content-lint-markdown
       - content-link-check
       - content-frontmatter-check
+      - content-policy-check
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -119,6 +132,7 @@ jobs:
       - content-lint-markdown
       - content-link-check
       - content-frontmatter-check
+      - content-policy-check
       - website-static-regen-on-content
       - website-sitemap-check
       - website-feed-check

--- a/blog/welcome.md
+++ b/blog/welcome.md
@@ -7,5 +7,6 @@ updatedAt: "2026-03-27"
 author: "Kriegspiel Team"
 tags: ["website", "announcement"]
 draft: false
+lifecycle: published
 ---
 Initial website-track content contract post.

--- a/changelog/2026-03-27-slice-910.md
+++ b/changelog/2026-03-27-slice-910.md
@@ -7,6 +7,7 @@ updatedAt: "2026-03-27"
 author: "Kriegspiel Team"
 tags: ["changelog", "step-900"]
 draft: false
+lifecycle: published
 version: "0.9.10"
 ---
 Completed Slice 910 contract baseline.

--- a/changelog/2026-03-27-slice-940-trust-discoverability.md
+++ b/changelog/2026-03-27-slice-940-trust-discoverability.md
@@ -7,6 +7,7 @@ updatedAt: 2026-03-27
 author: Kriegspiel Team
 tags: [changelog, step-900, seo, legal, analytics]
 draft: false
+lifecycle: published
 version: 0.9.40
 ---
 Completed Step 900 Slice 940.

--- a/docs/content-repository-organization.md
+++ b/docs/content-repository-organization.md
@@ -1,0 +1,51 @@
+# Content Repository Organization (Slice 960)
+
+## Canonical Layout
+
+```text
+blog/         published, review, and draft editorial posts
+changelog/    versioned product updates and release notes
+rules/        public rules references consumed by ks-home
+
+docs/         contributor-facing process and policy docs
+scripts/      repository validation/build tooling
+.github/      CI workflows and review routing
+```
+
+## Naming Policy
+
+- Filenames must be lowercase kebab-case with a `.md` suffix.
+- `blog/<slug>.md` must match the frontmatter `slug` exactly.
+- `changelog/<slug>.md` must match the frontmatter `slug` exactly; the slug must start with an ISO date prefix (`YYYY-MM-DD-...`).
+- `rules/<slug>.md` must match the frontmatter `slug` exactly.
+- Collection `README.md` files are allowed only as non-index documentation and are ignored by build loaders.
+
+## Lifecycle Policy
+
+Allowed values for `lifecycle`:
+
+- `draft` — preview-only work in progress; must keep `draft: true`
+- `review` — content awaiting editorial approval; must keep `draft: true`
+- `published` — public content; must keep `draft: false`
+- `archived` — historically preserved content excluded from active editing; must keep `draft: false`
+
+Additional rules:
+
+- Every content document in `blog/`, `changelog/`, and `rules/` must declare `lifecycle`.
+- `publishedAt` and `updatedAt` must remain valid dates for every lifecycle state.
+- Changelog and rules entries must continue to declare `version`.
+
+## Ownership
+
+- `CODEOWNERS` is the source of truth for required reviewers.
+- Changes touching public content, policy docs, or validation scripts must request review from the listed owners before merge.
+
+## CI Gate
+
+The blocking policy gate is `npm run validate:content-policy`.
+It verifies:
+
+- folder architecture exists
+- filename and slug policy
+- lifecycle metadata rules
+- CODEOWNERS coverage for required paths

--- a/docs/contributor-workflow.md
+++ b/docs/contributor-workflow.md
@@ -1,0 +1,43 @@
+# Contributor Workflow (Slice 960)
+
+## Create Draft Content
+
+1. Copy an existing markdown file from the target collection.
+2. Name the file using the collection rule:
+   - `blog/<slug>.md`
+   - `changelog/<yyyy-mm-dd-slug>.md`
+   - `rules/<slug>.md`
+3. Set frontmatter fields including `draft` and `lifecycle`.
+4. For work in progress, use:
+   - `draft: true`
+   - `lifecycle: draft`
+
+## Submit for Review
+
+1. Update `lifecycle` to `review` when the piece is ready for editorial review.
+2. Keep `draft: true` until the review is accepted.
+3. Open a PR; CODEOWNERS should auto-request reviewers.
+4. Run local validation before asking for merge:
+
+```bash
+npm ci
+npm run lint:markdown
+npm run lint:links
+npm run validate:frontmatter
+npm run validate:content-policy
+npm run build:content-index
+```
+
+## Publish
+
+1. Set `draft: false`.
+2. Set `lifecycle: published`.
+3. Confirm `publishedAt` and `updatedAt` are correct.
+4. Merge only after all content gates pass.
+
+## Archive
+
+1. Keep the file in its canonical collection path.
+2. Set `lifecycle: archived`.
+3. Keep `draft: false` so historical entries stay buildable and linkable.
+4. Add a short note in the body when archive context matters.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint:markdown": "node scripts/lint-markdown.mjs",
     "lint:links": "node scripts/lint-links.mjs",
     "validate:frontmatter": "node scripts/validate-frontmatter.mjs",
-    "build:content-index": "node scripts/build-content-index.mjs"
+    "build:content-index": "node scripts/build-content-index.mjs",
+    "validate:content-policy": "node scripts/check-content-policy.mjs"
   }
 }

--- a/rules/berkeley.md
+++ b/rules/berkeley.md
@@ -7,6 +7,7 @@ updatedAt: "2026-03-27"
 author: "Kriegspiel Team"
 tags: ["rules", "berkeley"]
 draft: false
+lifecycle: published
 version: "1.0.0"
 revision: "rules-berkeley-r1"
 lastReviewedAt: "2026-03-27"

--- a/rules/wild-16.md
+++ b/rules/wild-16.md
@@ -7,6 +7,7 @@ updatedAt: "2026-03-27"
 author: "Kriegspiel Team"
 tags: ["rules", "wild-16"]
 draft: false
+lifecycle: published
 version: "1.0.0"
 revision: "rules-wild16-r1"
 lastReviewedAt: "2026-03-27"

--- a/scripts/check-content-policy.mjs
+++ b/scripts/check-content-policy.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { listMarkdown, parseFrontmatter } from "./lib.mjs";
+
+const COLLECTIONS = ["blog", "changelog", "rules"];
+const ALLOWED_LIFECYCLES = new Set(["draft", "review", "published", "archived"]);
+const REQUIRED_PATHS = ["/blog/", "/changelog/", "/rules/", "/docs/", "/scripts/", "/.github/"];
+const codeownersPath = path.join(process.cwd(), ".github", "CODEOWNERS");
+const issues = [];
+
+for (const dir of ["blog", "changelog", "rules", "docs", "scripts", ".github/workflows"]) {
+  if (!fs.existsSync(path.join(process.cwd(), dir))) {
+    issues.push(`missing required path: ${dir}`);
+  }
+}
+
+const docs = listMarkdown();
+for (const doc of docs) {
+  const { metadata } = parseFrontmatter(doc.raw);
+  const base = path.basename(doc.file, ".md");
+  const slug = String(metadata.slug || "");
+  const lifecycle = String(metadata.lifecycle || "");
+
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(base)) {
+    issues.push(`${doc.dir}/${doc.file}: filename must be lowercase kebab-case`);
+  }
+
+  if (doc.dir === "changelog" && !/^\d{4}-\d{2}-\d{2}-[a-z0-9]+(?:-[a-z0-9]+)*$/.test(base)) {
+    issues.push(`${doc.dir}/${doc.file}: changelog filename must start with YYYY-MM-DD-`);
+  }
+
+  if (slug && slug !== base) {
+    issues.push(`${doc.dir}/${doc.file}: filename must match slug (${slug}.md)`);
+  }
+
+  if (!ALLOWED_LIFECYCLES.has(lifecycle)) {
+    issues.push(`${doc.dir}/${doc.file}: lifecycle must be one of ${Array.from(ALLOWED_LIFECYCLES).join(", ")}`);
+  }
+
+  if ((lifecycle === "draft" || lifecycle === "review") && metadata.draft !== true) {
+    issues.push(`${doc.dir}/${doc.file}: lifecycle ${lifecycle} requires draft: true`);
+  }
+
+  if ((lifecycle === "published" || lifecycle === "archived") && metadata.draft !== false) {
+    issues.push(`${doc.dir}/${doc.file}: lifecycle ${lifecycle} requires draft: false`);
+  }
+}
+
+if (!fs.existsSync(codeownersPath)) {
+  issues.push("missing .github/CODEOWNERS");
+} else {
+  const codeowners = fs.readFileSync(codeownersPath, "utf8");
+  for (const requiredPath of REQUIRED_PATHS) {
+    if (!codeowners.includes(requiredPath)) {
+      issues.push(`CODEOWNERS missing rule for ${requiredPath}`);
+    }
+  }
+  const ownerMentions = codeowners.match(/@[A-Za-z0-9_.-]+\/?[A-Za-z0-9_.-]*/g) || [];
+  if (ownerMentions.length === 0) {
+    issues.push("CODEOWNERS must assign at least one owner");
+  }
+}
+
+assert.equal(issues.length, 0, issues.join("\n"));
+console.log(`content-policy-check: PASS (${docs.length} content docs)`);

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -2,12 +2,15 @@ import fs from "node:fs";
 import path from "node:path";
 
 export const REQUIRED = ["title", "slug", "summary", "publishedAt", "updatedAt", "author", "tags", "draft"];
+export const CONTENT_COLLECTIONS = ["blog", "changelog", "rules"];
 
-export function listMarkdown(root = process.cwd()) {
-  return ["blog", "changelog"].flatMap((dir) => {
+export function listMarkdown(root = process.cwd(), collections = CONTENT_COLLECTIONS) {
+  return collections.flatMap((dir) => {
     const full = path.join(root, dir);
     if (!fs.existsSync(full)) return [];
-    return fs.readdirSync(full).filter((f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md").map((file) => ({ dir, file, fullPath: path.join(full, file), raw: fs.readFileSync(path.join(full, file), "utf8") }));
+    return fs.readdirSync(full)
+      .filter((f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md")
+      .map((file) => ({ dir, file, fullPath: path.join(full, file), raw: fs.readFileSync(path.join(full, file), "utf8") }));
   });
 }
 


### PR DESCRIPTION
## Summary
- document the canonical content repo layout and contributor workflow
- add CODEOWNERS and blocking content policy validation in CI
- enforce filename/slug/lifecycle policy across blog, changelog, and rules content

## Testing
- npm ci
- npm run lint:markdown
- npm run lint:links
- npm run validate:frontmatter
- npm run validate:content-policy
- npm run build:content-index
- cd /home/fil/dev/kriegspiel/ks-home && npm ci
- npm run content:trigger:simulate -- --from=../content --verify-static-regen
- npm run sitemap:generate -- --check
- npm run feeds:generate -- --check
- npm run build
- npm run test:smoke -- --routes=/,/blog,/changelog,/rules
