### PR TITLE
Add content-owned privacy and terms pages

### DIFF
--- a/docs/content-repository-organization.md
+++ b/docs/content-repository-organization.md
@@ -6,6 +6,7 @@
 blog/         published, review, and draft editorial posts
 changelog/    versioned product updates and release notes
 rules/        public rules references consumed by ks-home
+site/         singleton public pages consumed by ks-home (home, privacy, terms)
 
 docs/         contributor-facing process and policy docs
 scripts/      repository validation/build tooling
@@ -32,6 +33,7 @@ Allowed values for `lifecycle`:
 Additional rules:
 
 - Every content document in `blog/`, `changelog/`, and `rules/` must declare `lifecycle`.
+- `site/` singleton pages do not use lifecycle; they are consumed directly as canonical public pages.
 - `publishedAt` and `updatedAt` must remain valid dates for every lifecycle state.
 - Changelog and rules entries must continue to declare `version`.
 

--- a/docs/content-source-contract.md
+++ b/docs/content-source-contract.md
@@ -8,6 +8,8 @@ Kriegspiel/content is the source of truth for website collections consumed by ks
 - changelog/ -> changelog index + /changelog/:slug
 - rules/ -> rules index and rule details
 - site/home.md -> homepage/index copy and section content for /
+- site/privacy.md -> privacy policy page copy for /privacy
+- site/terms.md -> terms of use page copy for /terms
 
 ## Required frontmatter
 
@@ -24,6 +26,8 @@ Kriegspiel/content is the source of truth for website collections consumed by ks
 ## Home page content fields
 
 `site/home.md` must include the homepage copy keys consumed by `ks-home`, including hero, flow, features, CTA, and trust-snapshot fields plus CTA href/label values. Trust body copy may include `{{rulesCount}}` and `{{blogCount}}` placeholders, which `ks-home` resolves at build time from source-of-truth collection counts.
+
+`site/privacy.md` and `site/terms.md` are canonical public policy pages. Their markdown body is rendered by ks-home, while frontmatter supplies the route slug and page metadata.
 
 ## Contract checks
 

--- a/site/privacy.md
+++ b/site/privacy.md
@@ -1,0 +1,18 @@
+---
+title: "Privacy Policy"
+slug: "privacy"
+summary: "Privacy notice and analytics disclosure for Kriegspiel web properties."
+publishedAt: "2026-03-28T00:00:00.000Z"
+updatedAt: "2026-03-28T00:00:00.000Z"
+author: "Kriegspiel Team"
+tags: ["policy", "privacy"]
+draft: false
+---
+
+We collect only operational telemetry required to keep the service reliable and improve product quality.
+
+- No PII (name, email, IP, freeform text) in analytics events.
+- Events are scoped to product interactions and route performance.
+- Analytics can be disabled by consent controls where required.
+
+Policy owner: legal@kriegspiel.org

--- a/site/terms.md
+++ b/site/terms.md
@@ -1,0 +1,18 @@
+---
+title: "Terms of Use"
+slug: "terms"
+summary: "Terms of use for Kriegspiel website and related public services."
+publishedAt: "2026-03-28T00:00:00.000Z"
+updatedAt: "2026-03-28T00:00:00.000Z"
+author: "Kriegspiel Team"
+tags: ["policy", "terms"]
+draft: false
+---
+
+By using Kriegspiel web properties, you agree to fair-use and anti-abuse rules.
+
+- Do not abuse automated endpoints.
+- Content remains property of its authors and contributors.
+- Rules and policy revisions are documented in changelog entries.
+
+Policy owner: legal@kriegspiel.org


### PR DESCRIPTION
## Summary\n- add canonical site/privacy and site/terms markdown entries\n- document site singleton pages in the content source contract\n- clarify organization rules for content-owned singleton pages\n\n## Testing\n- npm run validate:frontmatter\n- npm run validate:content-policy\n