### PR TITLE
Rename Wild16 rules slug

### DIFF
--- a/rules/wild16.md
+++ b/rules/wild16.md
@@ -1,11 +1,11 @@
 ---
-title: "Wild 16 Kriegspiel Rules"
-slug: "wild-16"
-summary: "Wild 16 announcement and move validation pattern."
+title: "Wild16 Kriegspiel Rules"
+slug: "wild16"
+summary: "Wild16 announcement and move validation pattern used by major online play."
 publishedAt: "2026-03-27"
 updatedAt: "2026-03-27"
 author: "Kriegspiel Team"
-tags: ["rules", "wild-16"]
+tags: ["rules", "wild16", "wild-16"]
 draft: false
 lifecycle: published
 version: "1.0.0"


### PR DESCRIPTION
## Summary
- rename the Wild16 rules entry to use the canonical  slug
- update the displayed title/summary to match the site naming
- preserve searchability with both  and  tags

## Validation
- npm run lint:markdown
- npm run lint:links
- npm run validate:frontmatter
- npm run build:content-index
- npm run validate:content-policy