### PR TITLE
feat: add canonical site about and footer content

### DIFF
--- a/site/about/README.md
+++ b/site/about/README.md
@@ -1,0 +1,24 @@
+---
+title: "About"
+slug: "about"
+summary: "About Kriegspiel.org and the public website track."
+publishedAt: "2026-03-29"
+updatedAt: "2026-03-29"
+author: "Kriegspiel Team"
+tags: ["site", "about"]
+draft: false
+---
+Kriegspiel.org is the public home for the project: rules, changelog, editorial updates, and the website surface that explains what the product is doing.
+
+The app lives at [app.kriegspiel.org](https://app.kriegspiel.org/). This site exists to make the public-facing side legible: how to play, what changed, what the policies are, and where to follow development.
+
+## What this site covers
+
+- published rulesets and comparisons
+- changelog entries for public-facing work
+- blog posts and launch notes
+- policy pages and project links
+
+## What it does not replace
+
+This site does not replace the game client. If you want to play, use [Play online](https://app.kriegspiel.org/).

--- a/site/footer/README.md
+++ b/site/footer/README.md
@@ -1,0 +1,35 @@
+---
+title: "Footer"
+slug: "footer"
+summary: "Canonical footer content and link grouping for kriegspiel.org."
+publishedAt: "2026-03-29"
+updatedAt: "2026-03-29"
+author: "Kriegspiel Team"
+tags: ["site", "footer", "navigation"]
+draft: false
+---
+# Policy
+- [Privacy](/privacy)
+- [Terms](/terms)
+
+# Rules
+- [Berkeley](/rules/berkeley)
+- [Wild 16](/rules/wild16)
+- [Comparison](/rules/comparison/)
+
+# Communication
+- [Blog](/blog)
+- [Changelog](/changelog)
+- [About](/about)
+
+# Game
+- [Leaderboard](/leaderboard)
+- [Play online](https://app.kriegspiel.org/)
+
+# Development
+- [API docs](https://api.kriegspiel.org/docs)
+- [GitHub](https://github.com/Kriegspiel)
+
+# Social
+- [X.com](https://x.com/kriegspiel_org)
+- [GitHub](https://github.com/Kriegspiel)


### PR DESCRIPTION
## Summary
- add canonical `site/about/README.md`
- add canonical `site/footer/README.md`
- make footer content the source of truth in the content repo

## Notes
- uses `site/footer` instead of the typoed `site/footter`
- keeps footer/about content aligned for ks-home consumption
