### PR TITLE
feat: reorder shared footer groups

### DIFF
--- a/site/footer/README.md
+++ b/site/footer/README.md
@@ -8,28 +8,29 @@ author: "Kriegspiel Team"
 tags: ["site", "footer", "navigation"]
 draft: false
 ---
-# Policy
-- [Privacy](/privacy)
-- [Terms](/terms)
+# Game
+- [Leaderboard](/leaderboard)
+- [Play online](https://app.kriegspiel.org/)
 
 # Rules
 - [Berkeley](/rules/berkeley)
 - [Wild 16](/rules/wild16)
 - [Comparison](/rules/comparison/)
 
-# Communication
+# Comm
 - [Blog](/blog)
 - [Changelog](/changelog)
 - [About](/about)
 
-# Game
-- [Leaderboard](/leaderboard)
-- [Play online](https://app.kriegspiel.org/)
+# Policy
+- [Privacy](/privacy)
+- [Terms](/terms)
 
-# Development
+# Dev
 - [API docs](https://api.kriegspiel.org/docs)
 - [GitHub](https://github.com/Kriegspiel)
 
 # Social
 - [X.com](https://x.com/kriegspiel_org)
 - [GitHub](https://github.com/Kriegspiel)
+- [hi@kriegspiel.org](mailto:hi@kriegspiel.org)


### PR DESCRIPTION
## Summary
- reorder the canonical footer groups to Game, Rules, Comm, Policy, Dev, Social
- keep the existing footer link set intact while adding hi@kriegspiel.org under Social
- keep the footer markdown in content as the single shared source for site consumers

## Testing
- npm run lint:markdown
- npm run validate:frontmatter
- npm run build:content-index
- npm run validate:content-policy

## Notes
- \ currently fails in this repo because site-root routes such as \ and \ are treated as broken relative links by the existing checker; no new failures were introduced by this change.