### PR TITLE
Rename footer labels in shared footer

### DIFF
--- a/site/footer/README.md
+++ b/site/footer/README.md
@@ -17,7 +17,7 @@ draft: false
 - [Wild 16](/rules/wild16)
 - [Comparison](/rules/comparison/)
 
-# Comm
+# Communication
 - [Blog](/blog)
 - [Changelog](/changelog)
 - [About](/about)
@@ -26,7 +26,7 @@ draft: false
 - [Privacy](/privacy)
 - [Terms](/terms)
 
-# Dev
+# Development
 - [API docs](https://api.kriegspiel.org/docs)
 - [GitHub](https://github.com/Kriegspiel)
 


### PR DESCRIPTION
## Summary
- rename the shared footer group label  to 
- rename the shared footer group label  to 

## Verification
- ks-home build reflects updated headings
- ks-v2 app build reflects updated headings
- ks-v2 footer UI test updated and passing in companion PR
