### PR TITLE
Tighten rules landing summaries

### DIFF
--- a/rules/berkeley.md
+++ b/rules/berkeley.md
@@ -1,7 +1,7 @@
 ---
 title: "Berkeley Kriegspiel Rules"
 slug: "berkeley"
-summary: "Berkeley variant ruleset and referee announcement semantics."
+summary: "Classic referee calls: No/Nonsense, capture square, directional checks."
 publishedAt: "2026-03-27"
 updatedAt: "2026-03-27"
 author: "Kriegspiel Team"

--- a/rules/wild16.md
+++ b/rules/wild16.md
@@ -1,7 +1,7 @@
 ---
 title: "Wild16 Kriegspiel Rules"
 slug: "wild16"
-summary: "Wild16 announcement and move validation pattern used by major online play."
+summary: "ICC-style calls: illegal move, pawn tries, capture type, directional checks."
 publishedAt: "2026-03-27"
 updatedAt: "2026-03-27"
 author: "Kriegspiel Team"


### PR DESCRIPTION
## Summary
- shorten the Berkeley and Wild16 rules card summaries for /rules
- keep the summaries focused on each ruleset key referee behavior

## Testing
- npm run validate:frontmatter
