### PR TITLE
docs: simplify terms page

### DIFF
--- a/site/terms/README.md
+++ b/site/terms/README.md
@@ -1,18 +1,24 @@
 ---
 title: "Terms of Use"
 slug: "terms"
-summary: "Terms of use for Kriegspiel website and related public services."
+summary: "A brief plain-English summary of the basic rules for using Kriegspiel."
 publishedAt: "2026-03-28T00:00:00.000Z"
-updatedAt: "2026-03-28T00:00:00.000Z"
+updatedAt: "2026-03-31T00:00:00.000Z"
 author: "Kriegspiel Team"
 tags: ["policy", "terms"]
 draft: false
 ---
 
-By using Kriegspiel web properties, you agree to fair-use and anti-abuse rules.
+By using Kriegspiel, you agree to use it responsibly and not abuse, disrupt, or attack the service.
 
-- Do not abuse automated endpoints.
-- Content remains property of its authors and contributors.
-- Rules and policy revisions are documented in changelog entries.
+You are responsible for your account and for what happens through it.
 
-Policy owner: legal@kriegspiel.org
+We may suspend or remove accounts, content, or access if we see abuse, cheating, harassment, illegal use, or other behavior that harms the service or the community.
+
+Kriegspiel is provided **as is**. It may change, break, or be interrupted. We may update, limit, or remove features at any time.
+
+Games, content, ratings, messages, and even accounts may occasionally be lost, rolled back, unavailable, or removed. Please do not rely on the service as if it were guaranteed permanent storage.
+
+We may update these terms from time to time. If you keep using Kriegspiel after changes are posted here, that means you accept the revised terms.
+
+Questions about these terms: **legal@kriegspiel.org**


### PR DESCRIPTION
## Summary\n- rewrite the terms page in plain English\n- keep it short and aligned with the brief privacy page\n- cover responsible use, moderation, service changes, data loss risk, and updated-terms acceptance\n\n## Testing\n- npm run validate:frontmatter\n- npm run lint:markdown\n- npm run lint:links\n- npm run validate:content-policy\n- cd ../ks-home && npm run content:schema:check\n- cd ../ks-home && npm run content:source-contract:check\n- cd ../ks-home && npm run test -- --runInBand --watch=false\n- cd ../ks-home && npm run build