### PR TITLE
docs: humanize bot registration post

### DIFF
--- a/blog/2026-03-31_bot-registration-flow/README.md
+++ b/blog/2026-03-31_bot-registration-flow/README.md
@@ -1,7 +1,7 @@
 ---
 title: "How to register a bot on Kriegspiel.org"
 slug: "bot-registration-flow"
-summary: "The minimal registration and runtime flow for third-party or internal Kriegspiel bots."
+summary: "A simple guide to registering a bot, getting its API token, and connecting it to play on Kriegspiel.org."
 publishedAt: "2026-03-31"
 updatedAt: "2026-03-31"
 author: "Kriegspiel Team"
@@ -10,12 +10,14 @@ draft: false
 lifecycle: published
 ---
 
-Kriegspiel bots now use an explicit two-step flow:
+We want to introduce bots to the platform so they can play on Kriegspiel.org alongside human players.
 
-1. **Register once** to receive a bot API token.
-2. **Authenticate with that token** to list assigned games, read state, and submit moves.
+The flow is intentionally simple:
 
-## 1) Register a bot
+1. Register once to receive a bot API token.
+2. Authenticate with that token to list assigned games, read state, and submit moves.
+
+## 1. Register a bot
 
 Send a `POST` request to `/api/auth/bots/register`.
 
@@ -60,17 +62,19 @@ Example response:
 
 Save the token immediately. It is only returned once.
 
-## 2) Authenticate as the bot
+## 2. Authenticate as the bot
 
 Use the returned token as a bearer token:
 
-`Authorization: Bearer ksbot_<token-id>.<token-secret>`
+```http
+Authorization: Bearer ksbot_<token-id>.<token-secret>
+```
 
-## 3) List available bots for humans
+## 3. List available bots for humans
 
 Signed-in human players can load the lobby bot picker from `GET /api/bots`.
 
-## 4) Create a game against a bot
+## 4. Create a game against a bot
 
 Humans create bot games with:
 
@@ -88,16 +92,16 @@ Send that payload to `POST /api/game/create`.
 
 When `opponent_type` is `bot`, the backend immediately attaches the selected bot as the opponent and activates the game.
 
-## 5) Runtime loop for bot authors
+## 5. Runtime loop for bot authors
 
 1. `GET /api/game/mine`
-2. Filter to active games
+2. Filter to active games.
 3. `GET /api/game/{game_id}/state`
-4. If `turn` matches `your_color`, choose an action
+4. If `turn` matches `your_color`, choose an action.
 5. `POST /api/game/{game_id}/move`
-6. Repeat
+6. Repeat.
 
-The new `bot-random` repo follows exactly this flow.
+For a working example, see [`bot-random`](https://github.com/Kriegspiel/bot-random), which follows this flow end to end.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- make the bot registration post read more naturally
- fix list/header/code-block markdown rendering issues
- replace the old repo name with a proper bot-random link

## Testing
- npm run lint:markdown
- npm run lint:links
- npm run validate:frontmatter
- npm run validate:content-policy
- npm run build:content-index
- in ks-home: npm run content:trigger:simulate -- --from=../content --verify-static-regen
- in ks-home: KS_CONTENT_PATH=../content npm run sitemap:generate -- --check
- in ks-home: KS_CONTENT_PATH=../content npm run feeds:generate -- --check
- in ks-home: npm run build