### PR TITLE
feat: store blog snippets as tracked source files

### DIFF
--- a/blog/2026-03-31_bot-registration-flow/README.md
+++ b/blog/2026-03-31_bot-registration-flow/README.md
@@ -37,28 +37,11 @@ Required JSON body:
 
 Example request:
 
-```bash
-curl -X POST https://api.kriegspiel.org/api/auth/bots/register \
-  -H "Content-Type: application/json" \
-  -H "X-Bot-Registration-Key: $BOT_REGISTRATION_KEY" \
-  -d '{
-    "username": "randobot",
-    "display_name": "Random Bot",
-    "description": "Plays simple random moves"
-  }'
-```
+::include-code src="register-bot-request.sh"
 
 Example response:
 
-```json
-{
-  "bot_id": "67eb0f4f7d7e92c4e2f9c123",
-  "username": "randobot",
-  "display_name": "Random Bot",
-  "api_token": "ksbot_abcd1234.deadbeef...",
-  "message": "Bot registered. Save this token now; it will not be shown again."
-}
-```
+::include-code src="register-bot-response.json"
 
 Save the token immediately. It is only returned once.
 

--- a/blog/2026-03-31_bot-registration-flow/register-bot-request.sh
+++ b/blog/2026-03-31_bot-registration-flow/register-bot-request.sh
@@ -1,0 +1,8 @@
+curl -X POST https://api.kriegspiel.org/api/auth/bots/register \
+  -H "Content-Type: application/json" \
+  -H "X-Bot-Registration-Key: $BOT_REGISTRATION_KEY" \
+  -d '{
+    "username": "randobot",
+    "display_name": "Random Bot",
+    "description": "Plays simple random moves"
+  }'

--- a/blog/2026-03-31_bot-registration-flow/register-bot-response.json
+++ b/blog/2026-03-31_bot-registration-flow/register-bot-response.json
@@ -1,0 +1,7 @@
+{
+  "bot_id": "67eb0f4f7d7e92c4e2f9c123",
+  "username": "randobot",
+  "display_name": "Random Bot",
+  "api_token": "ksbot_abcd1234.deadbeef...",
+  "message": "Bot registered. Save this token now; it will not be shown again."
+}


### PR DESCRIPTION
## Summary
- move bot registration request/response examples into sibling tracked files
- reference them from the blog post with `::include-code`
- keep the source snippets GitHub-friendly and syntax-highlightable in the content repo

## Depends on
- ks-home PR for `::include-code` support

## Testing
- validated via ks-home build/test run after both branches were checked out together