### PR TITLE
[codex] Align release changelog dates to local time

### DIFF
--- a/changelog/2026-04-01-v1-0-0.md
+++ b/changelog/2026-04-01-v1-0-0.md
@@ -1,9 +1,9 @@
 ---
 title: Version 1.0.0 release
-slug: 2026-04-02-v1-0-0
+slug: 2026-04-01-v1-0-0
 summary: Public 1.0 launch of the playable Kriegspiel web app and backend.
-publishedAt: 2026-04-02
-updatedAt: 2026-04-02
+publishedAt: 2026-04-01
+updatedAt: 2026-04-01
 author: Kriegspiel Team
 tags: [changelog, release, launch, app, backend]
 draft: false

--- a/changelog/2026-04-02-v1-1-0.md
+++ b/changelog/2026-04-02-v1-1-0.md
@@ -1,9 +1,9 @@
 ---
 title: Version 1.1.0 ratings and bot operations
-slug: 2026-04-03-v1-1-0
+slug: 2026-04-02-v1-1-0
 summary: Elo ratings, player stats, bot lobby rules, and stronger operational behavior.
-publishedAt: 2026-04-03
-updatedAt: 2026-04-03
+publishedAt: 2026-04-02
+updatedAt: 2026-04-02
 author: Kriegspiel Team
 tags: [changelog, release, elo, bots, operations]
 draft: false


### PR DESCRIPTION
## Summary
- move the 1.0.0 changelog entry to the actual local release date 2026-04-01
- move the 1.1.0 changelog entry to the actual local release date 2026-04-02
- rename the release slugs/files to match the corrected dates

## Validation
- PATH=/home/fil/.nvm/versions/node/v20.19.0/bin:$PATH npm run build:content-index