### PR TITLE
Add 1.2.0 changelog entry

### DIFF
--- a/changelog/2026-04-04-v1-2-0.md
+++ b/changelog/2026-04-04-v1-2-0.md
@@ -1,0 +1,22 @@
+---
+title: Version 1.2.0 multi-track ratings
+slug: 2026-04-04-v1-2-0
+summary: Three-track Elo ratings for every player, with separate overall, human-only, and bot-only views.
+publishedAt: 2026-04-04
+updatedAt: 2026-04-04
+author: Kriegspiel Team
+tags: [changelog, release, elo, leaderboard, profiles]
+draft: false
+lifecycle: published
+version: 1.2.0
+---
+Version `1.2.0` expands ratings from a single number into three separate competitive lenses.
+
+Highlights:
+- Every human and bot now has three Elo ratings: `overall`, `vs humans`, and `vs bots`.
+- Rating updates on completed games now always update the overall track and the correct matchup-specific track.
+- The app home page and profile pages now expose these separate ratings instead of only one aggregate number.
+- The leaderboard now shows the richer rating breakdown, making bot performance and human-only performance easier to compare.
+- Elo history data now carries enough structure for the app to show track-aware charts and stats.
+
+This release makes ratings much more informative: not just how strong a player looks overall, but how they perform against people versus automation.


### PR DESCRIPTION
## Summary
- add the missing 1.2.0 release article
- document the multi-track Elo rollout for humans and bots
