### PR TITLE
[codex] Fix bot registration snippet

### DIFF
--- a/blog/2026-03-31_bot-registration-flow/register-bot-body.json
+++ b/blog/2026-03-31_bot-registration-flow/register-bot-body.json
@@ -1,5 +1,6 @@
 {
   "username": "randobot",
   "display_name": "Random Bot",
-  "description": "Plays simple random moves"
+  "owner_email": "bot-random@kriegspiel.org",
+  "description": "Plays simple random moves."
 }


### PR DESCRIPTION
## Summary
- add the required `owner_email` field to the bot registration JSON snippet
- add the missing period to the description example

## Validation
- `npm run build:content-index`
