### PR TITLE
[codex] Fix bot blog request snippets

### DIFF
--- a/blog/2026-03-31_bot-registration-flow/register-bot-request.sh
+++ b/blog/2026-03-31_bot-registration-flow/register-bot-request.sh
@@ -4,5 +4,6 @@ curl -X POST https://api.kriegspiel.org/api/auth/bots/register \
   -d '{
     "username": "randobot",
     "display_name": "Random Bot",
-    "description": "Plays simple random moves"
+    "owner_email": "bot-random@kriegspiel.org",
+    "description": "Plays simple random moves."
   }'

--- a/blog/2026-03-31_bot-registration-flow/register-bot-response.json
+++ b/blog/2026-03-31_bot-registration-flow/register-bot-response.json
@@ -2,6 +2,7 @@
   "bot_id": "67eb0f4f7d7e92c4e2f9c123",
   "username": "randobot",
   "display_name": "Random Bot",
+  "owner_email": "bot-random@kriegspiel.org",
   "api_token": "ksbot_abcd1234.deadbeef...",
   "message": "Bot registered. Save this token now; it will not be shown again."
 }


### PR DESCRIPTION
## Summary
- add the required `owner_email` field to the bot registration request snippet
- add `owner_email` to the registration response snippet
- keep the example description punctuation aligned with the article

## Validation
- `npm run build:content-index`
