### PR TITLE
Tighten Wild16 rules summary

### DIFF
--- a/rules/wild16.md
+++ b/rules/wild16.md
@@ -3,31 +3,44 @@ title: "Wild16 Kriegspiel Rules"
 slug: "wild16"
 summary: "ICC-style calls: illegal move, pawn tries, capture type, directional checks."
 publishedAt: "2026-03-27"
-updatedAt: "2026-03-27"
+updatedAt: "2026-04-05"
 author: "Kriegspiel Team"
 tags: ["rules", "wild16", "wild-16"]
 draft: false
 lifecycle: published
 version: "1.0.0"
-revision: "rules-wild16-r1"
-lastReviewedAt: "2026-03-27"
+revision: "rules-wild16-r2"
+lastReviewedAt: "2026-04-05"
 changelogSlug: "2026-03-27-slice-940-trust-discoverability"
 ---
-The computer referee makes the following announcements where appropriate:
+Wild 16 is broadly the same hidden-information game as Berkeley Kriegspiel, but with different referee wording and one major extra announcement rule. If you want the base game flow, piece movement, and general etiquette, read the Berkeley page first.
 
-- "White's move" 
-- "Black's move" 
-- "Pawn at "square" captured" 
-- "Piece at "square" captured" 
-- "Rank check" 
-- "File check" 
-- "Long-diagonal check" (the longer diagonal from the king's point of view) 
-- "Short-diagonal check" (e.g. for a king on e1, the short diagonal is e1 to h4) 
-- "Knight check" 
-- "*%number%* pawn tries" (number of legal capturing moves using pawns)
+## Key Differences From Berkeley
 
-When you try an illegal move, you are simply told "Illegal move", whether it is
-moving into check or moving through an enemy piece. Your opponent is not told
-anything when you try an illegal move.
+- Captures are announced by piece type:
+  - `Pawn at %square% captured`
+  - `Piece at %square% captured`
+- The Any rule is built in by default. Instead of a yes/no answer, the referee says:
+  - `%number% pawn tries`
+- Illegal moves are always answered with:
+  - `Illegal move`
 
-*Taken from [ICC Help](https://www.chessclub.com/user/help/Kriegspiel).*
+## Referee Announcements
+
+- `White's move`
+- `Black's move`
+- `Pawn at %square% captured`
+- `Piece at %square% captured`
+- `Rank check`
+- `File check`
+- `Long-diagonal check`
+- `Short-diagonal check`
+- `Knight check`
+- `%number% pawn tries`
+
+## Notes
+
+- Wild 16 should be read as a concise Berkeley-style variant, not as a full replacement for the Berkeley rules text.
+- The key practical change is that capture announcements distinguish pawns from other pieces, and pawn-capture availability is reported as a count rather than a yes/no answer.
+
+*Content adapted from [www.chessclub.com/help/Kriegspiel](https://www.chessclub.com/help/Kriegspiel).*


### PR DESCRIPTION
## Summary
- rewrite the Wild16 rules page into a shorter Berkeley-first structure
- list the key differences from Berkeley and the available announcements
- add the ICC source note and update the review metadata

## Testing
- npm run build:content-index