### PR TITLE
Broaden the research map summary

### DIFF
--- a/blog/2026-04-18_kriegspiel-research-map/README.md
+++ b/blog/2026-04-18_kriegspiel-research-map/README.md
@@ -1,7 +1,7 @@
 ---
 title: "A research map of Kriegspiel"
 slug: "kriegspiel-research-map"
-summary: "A compact guide to the main public research lines on Kriegspiel, from Anderson and UCLA to Bologna and Berkeley."
+summary: "A compact guide to public Kriegspiel research, key papers, and the academic history around the game."
 publishedAt: "2026-04-18"
 updatedAt: "2026-04-18"
 author: "Kriegspiel Team"


### PR DESCRIPTION
## Summary
- make the blog post summary more generic
- avoid naming specific research clusters in the short description
- keep the article body unchanged

## Testing
- npm run lint:markdown
- npm run lint:links
- npm run validate:frontmatter
- npm run validate:content-policy
- npm run build:content-index