### PR TITLE
Simplify the welcome launch note

### DIFF
--- a/blog/2026-03-27_welcome/README.md
+++ b/blog/2026-03-27_welcome/README.md
@@ -1,7 +1,7 @@
 ---
-title: "Welcome to Kriegspiel.org"
+title: "Launch notes for the website track"
 slug: "welcome"
-summary: "Launch notes for the website track."
+summary: "Just a launch note, to keep track of days."
 publishedAt: "2026-03-27"
 updatedAt: "2026-03-27"
 author: "Kriegspiel Team"
@@ -10,4 +10,4 @@ draft: false
 lifecycle: published
 ---
 
-Hello, world!
+Just a launch note, to keep track of days.


### PR DESCRIPTION
## Summary
- rename the welcome post to a simple launch-note style title
- shorten the summary and body so it reads like a lightweight launch note

## Why
- the current `/blog/welcome` entry should act as a minimal launch note for the website track
- the content should stay simple and date-oriented instead of feeling like a full editorial post

## Testing
- npm ci
- npm run lint:markdown
- npm run lint:links
- npm run validate:frontmatter
- npm run validate:content-policy
- npm run build:content-index

## Deployment notes
- this is content-only
- after merge, refresh the static site so the updated blog page goes live
