### PR TITLE
Normalize homepage hero capitalization

### DIFF
--- a/site/home/README.md
+++ b/site/home/README.md
@@ -8,7 +8,7 @@ author: "Kriegspiel Team"
 tags: ["homepage", "landing-page"]
 draft: false
 eyebrow: ""
-heroTitle: "Play Hidden-Information Chess Online"
+heroTitle: "Play hidden-information chess online"
 heroLede: "Simple, fun, and ready when you are. Jump into a game in your browser where you know your pieces, not your opponent’s board."
 heroPrimaryCtaLabel: "Play now"
 heroPrimaryCtaHref: "https://app.kriegspiel.org/"


### PR DESCRIPTION
## Summary
- change the public homepage hero title to sentence-style capitalization

## Why
- the hero line should read with only the first word capitalized

## Testing
- npm ci
- npm run lint:markdown
- npm run lint:links
- npm run validate:frontmatter
- npm run validate:content-policy
- npm run build:content-index

## Deployment notes
- content-only change
- refresh `ks-home` after merge so `kriegspiel.org` picks up the updated home copy
