### PR TITLE
Lowercase Berkeley rules title

### DIFF
--- a/rules/berkeley.md
+++ b/rules/berkeley.md
@@ -1,5 +1,5 @@
 ---
-title: "Berkeley Kriegspiel Rules"
+title: "Berkeley kriegspiel rules"
 slug: "berkeley"
 summary: "Classic referee calls: No/Nonsense, capture square, directional checks."
 publishedAt: "2026-03-27"


### PR DESCRIPTION
## Summary
- change the Berkeley rules page title from `Berkeley Kriegspiel Rules` to `Berkeley kriegspiel rules`

## Why
- the site should use only the first word capitalized for this rules title

## Testing
- `npm ci`
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`
