### PR TITLE
Shorten Cincinnati footer label

### DIFF
--- a/site/footer/README.md
+++ b/site/footer/README.md
@@ -14,7 +14,7 @@ draft: false
 
 # Rules
 - [Berkeley](/rules/berkeley)
-- [Cincinnati style](/rules/cincinnati)
+- [Cincinnati](/rules/cincinnati)
 - [Wild 16](/rules/wild16)
 - [Comparison](/rules/comparison/)
 


### PR DESCRIPTION
## Summary
- change the footer rules link label from `Cincinnati style` to `Cincinnati`

## Why
- the public footer should use the shorter label

## Testing
- `npm ci`
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`
- remote on `rpis02-cf` in `/home/fil/dev/kriegspiel/_tmp/content-cincinnati-label-fix`:
  - `npm ci`
  - `npm run validate:frontmatter`
  - verified `site/footer/README.md` contains `[Cincinnati](/rules/cincinnati)`
