### PR TITLE
Lowercase Cincinnati rules title

### DIFF
--- a/rules/cincinnati.md
+++ b/rules/cincinnati.md
@@ -1,5 +1,5 @@
 ---
-title: "Cincinnati-Style Kriegspiel Rules"
+title: "Cincinnati-style kriegspiel rules"
 slug: "cincinnati"
 summary: "Historical public rules with legal tries, Illegal vs Nonsense, pawn-capture notices, and typed capture announcements."
 publishedAt: "2026-04-18"


### PR DESCRIPTION
## Summary
- change the Cincinnati rules page title from `Cincinnati-Style Kriegspiel Rules` to `Cincinnati-style kriegspiel rules`

## Why
- the page title should use only the first word capitalized

## Testing
- `npm ci`
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`
