### PR TITLE
Simplify Cincinnati PDF link label

### DIFF
--- a/rules/cincinnati.md
+++ b/rules/cincinnati.md
@@ -112,6 +112,6 @@ Players should have promotion material available from the start for the same rea
 
 ## Source note
 
-This page was taken from the reproduction in [*Wargaming the Far Future* (PDF)](https://connections-wargaming.com/wp-content/uploads/2021/01/2019-wargaming-the-far-future-final-20191105.pdf), because the original David Moeser article has not yet been found.
+This page was taken from the reproduction in [Wargaming the Far Future (PDF)](https://connections-wargaming.com/wp-content/uploads/2021/01/2019-wargaming-the-far-future-final-20191105.pdf), because the original David Moeser article has not yet been found.
 
 Please email [any@kriegspiel.org](mailto:any@kriegspiel.org) if you have the original article or a better source for it.


### PR DESCRIPTION
## Summary
- change the Cincinnati source-note link label from `*Wargaming the Far Future* (PDF)` to plain `Wargaming the Far Future (PDF)`

## Why
- the markdown emphasis inside the link text is rendering poorly, so the source label should be plain clickable text

## Testing
- `npm ci`
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`
