### PR TITLE
docs: restore Cincinnati source wording

### DIFF
--- a/rules/cincinnati.md
+++ b/rules/cincinnati.md
@@ -3,112 +3,70 @@ title: "Cincinnati-style kriegspiel rules"
 slug: "cincinnati"
 summary: "Historical public rules with legal tries, Illegal vs Nonsense, pawn-capture notices, and typed capture announcements."
 publishedAt: "2026-04-18"
-updatedAt: "2026-04-18"
+updatedAt: "2026-04-19"
 author: "Kriegspiel Team"
 tags: ["rules", "cincinnati", "historical"]
 draft: false
 lifecycle: published
 version: "1.0.0"
 revision: "rules-cincinnati-r1"
-lastReviewedAt: "2026-04-18"
+lastReviewedAt: "2026-04-19"
 ---
 These rules are based on David Moeser's article **"Kriegspiel - Cincinnati style"**, which reportedly appeared in the March 30, 1977 issue of *J'ADOUBE!*, *The Cincinnati Chess Magazine*.
 
-## Core idea
+## The idea of Kriegspiel
 
-In Cincinnati-style Kriegspiel, the player on move keeps trying moves until one is legal on the referee's board.
-
-- A legal try becomes the player's actual move for the turn.
-- An illegal try is rejected and must be retracted.
-- Players may use tries not only to move, but also to learn something about the hidden position.
+The idea of Kriegspiel is this: The player on move attempts either to make a legal move, or to make moves called “tries” which have as their prime objective the obtaining of insight as to what the real position is. Any move or “try” which really is a legal move stands as that player's actual move in the game.
 
 ## Official and unofficial pieces
 
-Each player's own pieces are official.
+On his own board, each player's own pieces are “official”, and the Kriegspiel version of “if you touch you move” applies to them. They are for real, and their position must be identical to that shown on the Referee's board.
 
-- They must stay in the same positions as on the referee's board.
-- The Kriegspiel version of touch-move applies to them.
-- A player may touch her own piece only when actually making a try with it.
+The opposing pieces have no formal standing. Each player may set up pieces of the opposing color anywhere he wants, or not set them up at all; and he may move them any time he wants.
 
-The opponent's pieces are unofficial.
+The Referee must completely ignore opposing-color material on each player's board. It is not “official” and it may be on wrong or even absurd squares. The Referee must not allow himself to be confused by it.
 
-- A player may place them anywhere, or not place them at all.
-- A player may move them around freely on her own board.
-- The referee must ignore all opposing-color pieces on a player's board, even if they are on impossible squares.
+## The touch rule and tries
 
-## Touch rule and tries
+The Kriegspiel “touch” rule applies only to each player's own material: The Player is not allowed to touch his own material except for the purpose of making a try. That is, trying to make a legal move.
 
-The Cincinnati touch rule applies only to a player's own material.
+If a “try” is legal, it stands as the Player's real move. If it is not a legal move, the Player is not required to move (or try) that piece again.
 
-- Once a player tries a move with one of her own pieces, that try counts as the move attempt.
-- If the try is legal, it stands as the real move.
-- If the try is not legal, the player does **not** have to move that same piece again.
-
-The recommended referee procedure is to wait until the player lets go of the piece before saying anything. That avoids disputes about whether the try was really intended.
+The best procedure is for the Referee to require players to acquit (let go of) the piece they make a “try” with, and to say nothing until they do so. This requirement eliminates the kind of sticky situation where the Referee blurts out some information but the player says, “Oh, I didn't really mean to play that move!” and insists on the right to take it back because he is still holding onto the piece.
 
 ## Referee procedure
 
-After each legal move, and before the opponent starts the next turn, the referee:
+After each legal move is made, and before the Opponent begins his turn, the Referee records the move, makes it on his own set, and makes the announcements required by these rules.
 
-1. records the move,
-2. makes it on the official board, and
-3. gives all required announcements, and nothing more.
-
-All announcements must be heard by both players.
+It's important that the Referee announce all the information required by the rules -- and nothing else. All announcements must be heard by both players. Also, spectators must not talk openly about the game, for even casual comments can give away valuable information. Finally, the Referee must endeavor to be 100% correct, or else the game is likely to be ruined.
 
 ## Referee announcements
 
-### Legal or illegal tries
+If a “try” is a legal move, the Referee simply announces that the Player has moved. “Black has moved”, he says. Or “White to move”. After a while the Ref is likely to abbreviate this notification: “White”. “Black”. “White”, he'll say.
 
-- If a try is legal, the referee announces that the player has moved, for example: `White has moved`, `Black has moved`, or simply `White`, `Black`.
-- If a try is illegal on the true board, the referee says `Illegal` or `No`.
-- If the try is impossible in a way the player must already know, the referee says `Nonsense`.
+However, if a “try” isn't a legal move, the Referee says “No” or “Illegal”, and that try must be retracted. If the move is impossible, and the player must know it for some reason, like trying to capture one's own pieces, the Referee's appropriate response is “Nonsense”. The “Nonsense” announcement discourages a Player from wasting time or attempting to use the Referee to mislead the Opponent.
 
-The `Nonsense` call is meant to stop obviously absurd or misleading tries, such as trying to capture your own piece or attempting a pawn capture when no pawn capture announcement is in force.
+The player continues to try to make a move until he finds one that is legal.
 
-### Capture
+When a legal move is completed, the Referee announces whichever of the following information is appropriate:
 
-After a legal move, the referee announces:
-
-1. that a capture happened,
-2. the square from which the captured piece must be removed, and
-3. whether the captured material was a `pawn` or a `piece`.
-
-If the captured material was a piece, the referee does **not** reveal which piece it was.
-
-### Check
-
-If the move gives check, the referee announces both the fact of check and its direction relative to the checked king:
-
-- `file`
-- `rank`
-- `long diagonal`
-- `short diagonal`
-- `Knight`
-
-### Pawn capture announcement
-
-If at least one pawn of the player to move can legally capture something, the referee announces that the player has a `pawn capture`.
-
-That means:
-
-- at least one pawn capture is legally available,
-- the referee does **not** reveal where that capture is,
-- the player may alternate between piece tries and pawn tries in any order,
-- the referee must repeat the announcement on every turn where such a pawn capture exists.
-
-There is one important check exception: if the player is in check, and a pawn capture exists somewhere on the board but **none** of those pawn captures would remove the check, the referee does **not** announce a pawn capture.
-
-If a player tries a pawn capture when no pawn capture announcement applies, the referee says `Nonsense`.
+1. If a capture has been made, the fact of the capture and the square the captured piece is to be removed from. (Keep this wording in mind for an en passant capture.)
+2. Whether the captured material was a pawn or a piece — but if a piece, not what kind of piece.
+3. If a check has been made, the fact that the Opponent is now in check, and the direction of check with respect to the Opponent's King: whether that King is in check on a file, on a rank, on the long diagonal, on the short diagonal, or by a Knight.
+4. Pawn captures:
+   - **a.** If any of the pawns of the Player on move can capture anything, the Referee announces that the Player now has a “pawn capture”, which means that at least one of his pawns can legally capture something (anything) of the Opponent's. The Referee does not tell where on the board any such capture is. The Player may now try to make captures with his pawns, or he may not. He may make tries with pieces, then tries (either possible moves or possible captures) with pawns, go back to pieces, then go back to pawn tries, etc.
+   - **b.** Due to the pawn's unique capturing power (its capturing “vector” is different from its move), a Player who attempts pawn captures when the Referee has not announced there are any is trying nonsense. In this instance the Referee announces “Nonsense” so the Opponent is not unfairly confused. (For example, the Opponent would be led to believe the Player still has a lot of material on the board when he really does not.)
+   - **c.** Knotty point: If a Player is in check and has a pawn capture on the board, but no such pawn capture will remove the check, does the Referee announce the pawn capture? Answer: no.
+   - **d.** As long as at least one pawn capture is on the board, the Referee must announce that a pawn capture is possible -- and continue to do so every time the Player on move has a pawn capture available. (Note: This is because announcements apply only to the move on which they are announced.)
 
 ## What is not announced
 
-- Piece captures by non-pawns are **not** announced in advance.
-- Pawn promotion is **not** announced.
-- The referee does **not** give a material count during the game.
-- Castling and promotion should be handled silently on the referee's board so they do not reveal extra information through tone, delay, or gesture.
+The following rules elaborate on certain prohibitions:
 
-Players should have promotion material available from the start for the same reason.
+1. If a piece, non-pawn, can capture something, that is not announced.
+2. Promotion of pawns is not announced. Each player should be supplied with extra promotion material at the beginning of the game.
+3. The Referee may not give a count of material on the board during the game.
+4. On the Referee's board such moves as castling or pawn promotion must be made silently and without any noticeable delay, so as not to reveal the nature of these unique movements. It is in the players' interest to do likewise. This is why the players should have promotion material available at the start of the game.
 
 ## Source note
 


### PR DESCRIPTION
## Summary
- replace the paraphrased Cincinnati rules page with a closer transcription of the source text you provided
- keep the page structured with readable Markdown headings and lists
- update the page metadata review date to `2026-04-19`

## Why
The previous version was a clean summary, but you asked for the Cincinnati rules page to stay much closer to the surviving source wording. This update keeps the same page structure while using the source text much more directly.

## Testing
- `npm ci`
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`

## Deploy
- fast-forward `/home/fil/dev/kriegspiel/content`
- refresh `ks-home`
- verify `https://kriegspiel.org/rules/cincinnati`
