### PR TITLE
docs: fix Cincinnati source reference

### DIFF
--- a/rules/cincinnati.md
+++ b/rules/cincinnati.md
@@ -70,6 +70,6 @@ The following rules elaborate on certain prohibitions:
 
 ## Source note
 
-This page was taken from the reproduction in [Wargaming the Far Future (PDF)](https://connections-wargaming.com/wp-content/uploads/2021/01/2019-wargaming-the-far-future-final-20191105.pdf), because the original David Moeser article has not yet been found.
+This page was taken from the appendix in [La Scacchiera Invisibile (PDF)](https://www.cs.unibo.it/~paolo.ciancarini/wwwpages/chesssite/kriegspiel/scacchierainvisibile.pdf), because the original David Moeser article has not yet been found.
 
 Please email [any@kriegspiel.org](mailto:any@kriegspiel.org) if you have the original article or a better source for it.


### PR DESCRIPTION
## Summary
- update the Cincinnati rules source note to cite the Bologna PDF directly
- replace the old `Wargaming the Far Future` reference with `La Scacchiera Invisibile`

## Why
You pointed out that the reference should be to the Bologna paper instead of the secondary reproduction link.

## Testing
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`

## Deploy
- fast-forward `/home/fil/dev/kriegspiel/content`
- refresh `ks-home`
- verify `https://kriegspiel.org/rules/cincinnati`
