### PR TITLE
docs: remove duplicate Wild 16 heading

### DIFF
--- a/rules/wild16.md
+++ b/rules/wild16.md
@@ -13,8 +13,6 @@ revision: "rules-wild16-r3"
 lastReviewedAt: "2026-04-19"
 changelogSlug: "2026-03-27-slice-940-trust-discoverability"
 ---
-# Wild 16 / ICC kriegspiel rules
-
 Wild 16 is the Internet Chess Club version of Kriegspiel: chess with hidden information. Each player sees only their own pieces. The referee or server sees the full position and decides whether attempted moves are legal.
 
 ## 1. Basic idea


### PR DESCRIPTION
## Summary
- remove the extra top-level markdown heading from the Wild 16 rules body
- keep the page title coming only from frontmatter / page chrome

## Why
The detailed Wild 16 rewrite rendered with two `<h1>` elements on the live page. This removes the duplicate body heading.

## Testing
- `npm run lint:markdown`
- `npm run validate:frontmatter`

## Deploy
- fast-forward `/home/fil/dev/kriegspiel/content`
- refresh `ks-home`
- verify `https://kriegspiel.org/rules/wild16` shows only one main heading
