### PR TITLE
Use stable CrazyKrieg source link

### DIFF
--- a/rules/crazykrieg.md
+++ b/rules/crazykrieg.md
@@ -266,4 +266,4 @@ After promotion:
 
 ## Source note
 
-This page summarizes original-style CrazyKrieg, also called Crazyhouse Kriegspiel, and uses the historical [Chess Variant Pages Crazyhouse Kriegspiel entry](https://ftp.chessvariants.com/incinf.dir/crazyhousekriegspiel.html), standard [Kriegspiel referee-announcement rules](https://en.wikipedia.org/wiki/Kriegspiel_%28chess%29), and standard [Crazyhouse reserve/drop rules](https://lichess.org/variant/crazyhouse) as references.
+This page summarizes original-style CrazyKrieg, also called Crazyhouse Kriegspiel, and uses the historical [Chess Variant Pages Crazyhouse Kriegspiel entry](https://www.chessvariants.org/incinf.dir/crazyhousekriegspiel.html), standard [Kriegspiel referee-announcement rules](https://en.wikipedia.org/wiki/Kriegspiel_%28chess%29), and standard [Crazyhouse reserve/drop rules](https://lichess.org/variant/crazyhouse) as references.


### PR DESCRIPTION
## Summary

- Switch the CrazyKrieg rules source note from the older `ftp.chessvariants.com` mirror to the current Chess Variant Pages URL.
- Keep the published CrazyKrieg reference source clickable and stable.

## Validation

- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`
