### PR TITLE
Clarify policy acceptance copy

### DIFF
--- a/site/privacy/README.md
+++ b/site/privacy/README.md
@@ -3,11 +3,13 @@ title: "Privacy Policy"
 slug: "privacy"
 summary: "A brief plain-English summary of what data Kriegspiel collects and why."
 publishedAt: "2026-03-28T00:00:00.000Z"
-updatedAt: "2026-03-31T00:00:00.000Z"
+updatedAt: "2026-04-29T00:00:00.000Z"
 author: "Kriegspiel Team"
 tags: ["policy", "privacy"]
 draft: false
 ---
+
+By accessing or using the Kriegspiel website, including registering, logging in, or playing as a guest, you acknowledge this Privacy Policy and agree to the [Terms of Use](/terms).
 
 We collect a few basic kinds of data to run Kriegspiel:
 

--- a/site/terms/README.md
+++ b/site/terms/README.md
@@ -3,13 +3,15 @@ title: "Terms of Use"
 slug: "terms"
 summary: "A brief plain-English summary of the basic rules for using Kriegspiel."
 publishedAt: "2026-03-28T00:00:00.000Z"
-updatedAt: "2026-03-31T00:00:00.000Z"
+updatedAt: "2026-04-29T00:00:00.000Z"
 author: "Kriegspiel Team"
 tags: ["policy", "terms"]
 draft: false
 ---
 
-By using Kriegspiel, you agree to use it responsibly and not abuse, disrupt, or attack the service.
+By accessing or using the Kriegspiel website, including browsing public pages, registering, logging in, or playing as a guest, you agree to these Terms of Use and acknowledge the [Privacy Policy](/privacy).
+
+You agree to use Kriegspiel responsibly and not abuse, disrupt, or attack the service.
 
 You are responsible for your account and for what happens through it.
 


### PR DESCRIPTION
## Summary

- Add explicit website-use acceptance/acknowledgement language to Privacy Policy and Terms of Use.
- Update both policy pages' `updatedAt` metadata to `2026-04-29T00:00:00.000Z`.

## Testing

- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`

## Deployment notes

- Deploy before the `ks-home` PR so the public policy pages are regenerated with the new copy.
