### PR TITLE
Add 1.3.0 guest games changelog

### DIFF
--- a/changelog/2026-04-29-v1-3-0.md
+++ b/changelog/2026-04-29-v1-3-0.md
@@ -1,0 +1,29 @@
+---
+title: Version 1.3.0 guest games
+slug: 2026-04-29-v1-3-0
+summary: Guest play, broader ruleset support, stronger reviews, and smoother live-game ergonomics.
+publishedAt: 2026-04-29
+updatedAt: 2026-04-29
+author: Kriegspiel Team
+tags: [changelog, release, guests, rulesets, reviews, operations]
+draft: false
+lifecycle: published
+version: 1.3.0
+---
+Version `1.3.0` makes Kriegspiel easier to try and more complete to study.
+
+The main change is guest games: new players can now start playing without creating an account. The app offers a `Play as guest` path, and the backend creates a session-backed guest identity with a generated `guest_first_last` username. Guest sessions are designed to last a long time in the same browser, while still keeping guest accounts low-privilege.
+
+Major improvements since `1.2.0`:
+
+- Guest play is live across the app and backend, including long-lived browser sessions and guest-safe game metadata.
+- Cincinnati and Wild 16 became first-class playable rulesets, with backend support, frontend game flows, bot compatibility, review handling, and ruleset-specific referee announcements.
+- The shared game engine now has neutral `KriegspielGame` entry points, dedicated Wild 16 and Cincinnati wrappers, stronger serialization, and tighter ruleset isolation so Berkeley, Cincinnati, and Wild 16 behavior do not leak into each other.
+- Review pages and game histories now show rulesets, orient a user's own replays correctly, expose Wild 16 private illegal attempts after the game, and place turn-start pawn-capture announcements in the right ply.
+- The in-game current-message panel and referee log are calmer: duplicate announcements are collapsed, turn-start pawn-capture status belongs to the current player, and the log auto-scrolls only after completed turns.
+- Game-end summaries became more useful, with outcome details, rating changes, clickable player names, bot labels, and a clear review call to action.
+- Live play received practical board improvements: engine-owned remaining-material summaries, better clock behavior, softer opening phantoms, board-width clocks, and last-selected ruleset memory in the lobby.
+- Production monitoring improved with Sentry on the frontend and backend, including backend restart events so deploys and reboots are visible.
+- The public rules site grew substantially, adding Cincinnati, RAND, English, and CrazyKrieg references, a richer comparison table, mobile/table polish, and updated legal/privacy acceptance copy.
+
+In short: `1.3.0` is the "try it now" release. It lowers the first-play barrier with guest games while making the platform's rulesets, reviews, and operations much more mature.


### PR DESCRIPTION
## Summary

- Add the public `1.3.0` changelog entry.
- Lead with guest games as the main release improvement.
- Summarize major improvements since `1.2.0`: Cincinnati and Wild 16, engine/ruleset isolation, reviews and histories, current-message/referee-log polish, game-end summaries, board/clocks/material UX, Sentry monitoring, and public rules-site updates.

## Local validation

- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`
- rendered with `ks-home` using `KS_CONTENT_PATH` and verified the `1.3.0` entry appears above `1.2.0` on the changelog index

Result: all passed.