### PR TITLE
Clarify bot game references

### DIFF
--- a/blog/2026-03-31_bot-registration-flow/README.md
+++ b/blog/2026-03-31_bot-registration-flow/README.md
@@ -22,9 +22,9 @@ A bot account is just a special account with a bearer token. After registration,
 
 1. Load its saved token.
 2. Poll `GET /api/game/mine/active`.
-3. For each active game, call `GET /api/game/{game_id}/state`.
+3. For each active game, call `GET /api/game/{game_ref}/state`.
 4. If it is the bot's turn, choose an allowed action.
-5. Submit either `POST /api/game/{game_id}/move` or `POST /api/game/{game_id}/ask-any`.
+5. Submit either `POST /api/game/{game_ref}/move` or `POST /api/game/{game_ref}/ask-any`.
 6. Optionally create one open waiting game, or occasionally join another bot's waiting game.
 7. Repeat politely.
 
@@ -219,12 +219,15 @@ For each active game assigned to the bot, call:
 
 ::include-code src="get-game-state.http"
 
+`game_ref` can be either the six-character public `game_code` or the internal `game_id` returned by game metadata endpoints. Public URLs use the code; current API state responses still expose `game_id` as the backend document id.
+
 A typical state contains:
 
 ::include-code src="game-state-response.json"
 
 The important fields for a bot are:
 
+- `game_id`: the API's internal id for the game, not the six-character public `game_code`.
 - `your_color`: the side this bot controls.
 - `turn`: whose turn it is.
 - `possible_actions`: usually `["move"]`, or `["move", "ask_any"]` when `Any?` is available.

--- a/blog/2026-03-31_bot-registration-flow/ask-any.http
+++ b/blog/2026-03-31_bot-registration-flow/ask-any.http
@@ -1,2 +1,2 @@
-POST /api/game/67eb10247d7e92c4e2f9c456/ask-any
+POST /api/game/K2Q9MJ/ask-any
 Authorization: Bearer ksbot_<token-id>.<token-secret>

--- a/blog/2026-03-31_bot-registration-flow/get-game-state.http
+++ b/blog/2026-03-31_bot-registration-flow/get-game-state.http
@@ -1,2 +1,2 @@
-GET /api/game/67eb10247d7e92c4e2f9c456/state
+GET /api/game/K2Q9MJ/state
 Authorization: Bearer ksbot_<token-id>.<token-secret>

--- a/blog/2026-03-31_bot-registration-flow/runtime-loop.txt
+++ b/blog/2026-03-31_bot-registration-flow/runtime-loop.txt
@@ -3,9 +3,9 @@
 3. GET /api/game/mine/active.
 4. If under the local active-game limit, maybe create one open waiting game.
 5. Maybe fetch /api/game/open and join another bot-created waiting game.
-6. For each active game, GET /api/game/{game_id}/state.
+6. For each active game, GET /api/game/{game_ref}/state.
 7. If it is not your turn, leave the game alone.
-8. If ask_any is available and your strategy wants it, POST /api/game/{game_id}/ask-any.
+8. If ask_any is available and your strategy wants it, POST /api/game/{game_ref}/ask-any.
 9. Otherwise choose one move from allowed_moves.
-10. POST /api/game/{game_id}/move.
+10. POST /api/game/{game_ref}/move.
 11. On network errors, back off and poll again.

--- a/blog/2026-03-31_bot-registration-flow/submit-move.http
+++ b/blog/2026-03-31_bot-registration-flow/submit-move.http
@@ -1,4 +1,4 @@
-POST /api/game/67eb10247d7e92c4e2f9c456/move
+POST /api/game/K2Q9MJ/move
 Authorization: Bearer ksbot_<token-id>.<token-secret>
 Content-Type: application/json
 


### PR DESCRIPTION
## Summary
- explain that game_ref can be either game_code or game_id
- switch bot state/move/ask-any HTTP examples to a six-character public game code
- call out that GameStateResponse.game_id is still the backend document id

## Verification
- npm run validate:frontmatter
- npm run lint:markdown
- npm run lint:links
- npm run validate:content-policy
- npm run build:content-index
- git diff --check