### PR TITLE
docs: use prefix-free bot API examples

### DIFF
--- a/blog/2026-03-31_bot-registration-flow/README.md
+++ b/blog/2026-03-31_bot-registration-flow/README.md
@@ -14,17 +14,17 @@ Bots are first-class players on Kriegspiel.org. They can play humans, play other
 
 This guide is the practical version of the bot contract. It explains what the platform guarantees, what your bot must do, which API routes matter, and how to handle the awkward cases: stale tokens, unsupported rulesets, model-provider quota limits, illegal moves, waiting games, and bot-vs-bot rate limits.
 
-The examples use `https://api.kriegspiel.org/api/...` because that route shape is stable for public clients. The backend also exposes canonical routes without `/api` for internal clients. Pick one base URL and be consistent inside your bot.
+The examples use the public API host, `https://api.kriegspiel.org`, with prefix-free paths such as `/game/mine/active`. The browser app has a separate same-origin `/api/...` ingress on `app.kriegspiel.org`; bot code and other external clients should use the prefix-free API host contract.
 
 ## The short version
 
 A bot account is just a special account with a bearer token. After registration, a bot usually runs this loop:
 
 1. Load its saved token.
-2. Poll `GET /api/game/mine/active`.
-3. For each active game, call `GET /api/game/{game_ref}/state`.
+2. Poll `GET /game/mine/active`.
+3. For each active game, call `GET /game/{game_ref}/state`.
 4. If it is the bot's turn, choose an allowed action.
-5. Submit either `POST /api/game/{game_ref}/move` or `POST /api/game/{game_ref}/ask-any`.
+5. Submit either `POST /game/{game_ref}/move` or `POST /game/{game_ref}/ask-any`.
 6. Optionally create one open waiting game, or occasionally join another bot's waiting game.
 7. Repeat politely.
 
@@ -48,7 +48,7 @@ These bots are intentionally readable. They are not meant to be unbeatable playe
 
 Bot registration is controlled by a shared registration key. If you want to run a bot on the public platform, ask the Kriegspiel.org maintainers for access first. The key is not the bot token; it is only used to create or rotate bot accounts.
 
-Send a `POST` request to `/api/auth/bots/register`.
+Send a `POST` request to `/auth/bots/register`.
 
 Required header:
 
@@ -94,7 +94,7 @@ If a bot loses its token, rotate the account through the registration process in
 
 ## How humans see bots
 
-The human lobby calls `GET /api/bots` while the lobby is loading. The dropdown does not hard-code bot names; it shows only what the backend returns.
+The backend bot list route is `GET /bots`. The human lobby reaches the same handler through its same-origin app ingress while the lobby is loading, and the dropdown does not hard-code bot names; it shows only what the backend returns.
 
 ::include-code src="list-bots.http"
 
@@ -140,7 +140,7 @@ This availability gate protects direct game creation too. Even if a browser has 
 
 ## Human-created bot games
 
-When a human chooses a bot in the lobby, the frontend sends `POST /api/game/create` with `opponent_type: "bot"` and a `bot_id`.
+When a human chooses a bot in the lobby, the game-creation request reaches `POST /game/create` with `opponent_type: "bot"` and a `bot_id`.
 
 ::include-code src="create-bot-game-request.json"
 
@@ -185,7 +185,7 @@ Join request:
 The bot should also make its own local decision before joining. The official bots do this:
 
 - Check whether they are under their active-game limit.
-- Fetch `GET /api/game/open`.
+- Fetch `GET /game/open`.
 - Filter to games created by other bots.
 - Filter to rulesets they support.
 - Respect their own sampling probability.
@@ -203,7 +203,7 @@ Archived games are available separately:
 
 ::include-code src="get-archived-games.http"
 
-The older `GET /api/game/mine` endpoint still exists for compatibility, but active bots should not use it as their main loop. It can include archived metadata and is not the right performance target for live play.
+The older `GET /game/mine` endpoint still exists for compatibility, but active bots should not use it as their main loop. It can include archived metadata and is not the right performance target for live play.
 
 ## Read open lobby games
 
@@ -304,7 +304,7 @@ Useful bot environment variables in the example repos include:
 
 | Variable | Meaning |
 | --- | --- |
-| `KRIEGSPIEL_API_BASE` | API base URL. Use `https://api.kriegspiel.org` if your code appends `/api/...`; use `https://api.kriegspiel.org/api` only if your code appends prefixless paths such as `/game/...`. Avoid accidentally doubling `/api`. |
+| `KRIEGSPIEL_API_BASE` | API base URL for external clients. Use `https://api.kriegspiel.org` with prefix-free paths such as `/game/mine/active`. Do not add `/api` when targeting `api.kriegspiel.org`. |
 | `KRIEGSPIEL_BOT_TOKEN` | Bearer token returned at registration. |
 | `KRIEGSPIEL_BOT_USERNAME` | Bot username, used to filter the bot's own waiting games. |
 | `KRIEGSPIEL_AUTO_CREATE_LOBBY_GAME` | Whether the bot should create open waiting games. |
@@ -337,7 +337,7 @@ If in doubt, list fewer rulesets. A bot that plays two rulesets correctly is muc
 Bots share the live site with human players. Please keep them boring in the best way:
 
 - Poll active games on a steady interval, not in a tight loop.
-- Use `GET /api/game/mine/active` for live work.
+- Use `GET /game/mine/active` for live work.
 - Keep one waiting game open at most.
 - Respect bot-vs-bot join limits.
 - Report model availability if provider health determines whether the bot can play.

--- a/blog/2026-03-31_bot-registration-flow/ask-any.http
+++ b/blog/2026-03-31_bot-registration-flow/ask-any.http
@@ -1,2 +1,2 @@
-POST /api/game/K2Q9MJ/ask-any
+POST /game/K2Q9MJ/ask-any
 Authorization: Bearer ksbot_<token-id>.<token-secret>

--- a/blog/2026-03-31_bot-registration-flow/get-active-games.http
+++ b/blog/2026-03-31_bot-registration-flow/get-active-games.http
@@ -1,2 +1,2 @@
-GET /api/game/mine/active
+GET /game/mine/active
 Authorization: Bearer ksbot_<token-id>.<token-secret>

--- a/blog/2026-03-31_bot-registration-flow/get-archived-games.http
+++ b/blog/2026-03-31_bot-registration-flow/get-archived-games.http
@@ -1,2 +1,2 @@
-GET /api/game/mine/archived
+GET /game/mine/archived
 Authorization: Bearer ksbot_<token-id>.<token-secret>

--- a/blog/2026-03-31_bot-registration-flow/get-game-state.http
+++ b/blog/2026-03-31_bot-registration-flow/get-game-state.http
@@ -1,2 +1,2 @@
-GET /api/game/K2Q9MJ/state
+GET /game/K2Q9MJ/state
 Authorization: Bearer ksbot_<token-id>.<token-secret>

--- a/blog/2026-03-31_bot-registration-flow/get-open-games.http
+++ b/blog/2026-03-31_bot-registration-flow/get-open-games.http
@@ -1,2 +1,2 @@
-GET /api/game/open
+GET /game/open
 Authorization: Bearer ksbot_<token-id>.<token-secret>

--- a/blog/2026-03-31_bot-registration-flow/join-game.http
+++ b/blog/2026-03-31_bot-registration-flow/join-game.http
@@ -1,2 +1,2 @@
-POST /api/game/join/H7K2M9
+POST /game/join/H7K2M9
 Authorization: Bearer ksbot_<token-id>.<token-secret>

--- a/blog/2026-03-31_bot-registration-flow/list-bots.http
+++ b/blog/2026-03-31_bot-registration-flow/list-bots.http
@@ -1,1 +1,1 @@
-GET /api/bots
+GET /bots

--- a/blog/2026-03-31_bot-registration-flow/model-availability-report.http
+++ b/blog/2026-03-31_bot-registration-flow/model-availability-report.http
@@ -1,3 +1,3 @@
-POST /api/bots/availability
+POST /bots/availability
 Authorization: Bearer ksbot_<token-id>.<token-secret>
 Content-Type: application/json

--- a/blog/2026-03-31_bot-registration-flow/register-bot-request.sh
+++ b/blog/2026-03-31_bot-registration-flow/register-bot-request.sh
@@ -1,4 +1,4 @@
-curl -X POST https://api.kriegspiel.org/api/auth/bots/register \
+curl -X POST https://api.kriegspiel.org/auth/bots/register \
   -H "Content-Type: application/json" \
   -H "X-Bot-Registration-Key: $BOT_REGISTRATION_KEY" \
   -d '{

--- a/blog/2026-03-31_bot-registration-flow/runtime-loop.txt
+++ b/blog/2026-03-31_bot-registration-flow/runtime-loop.txt
@@ -1,11 +1,11 @@
 1. Restore or register the bot token.
 2. If this is a model bot, check provider health and report availability.
-3. GET /api/game/mine/active.
+3. GET /game/mine/active.
 4. If under the local active-game limit, maybe create one open waiting game.
-5. Maybe fetch /api/game/open and join another bot-created waiting game.
-6. For each active game, GET /api/game/{game_ref}/state.
+5. Maybe fetch /game/open and join another bot-created waiting game.
+6. For each active game, GET /game/{game_ref}/state.
 7. If it is not your turn, leave the game alone.
-8. If ask_any is available and your strategy wants it, POST /api/game/{game_ref}/ask-any.
+8. If ask_any is available and your strategy wants it, POST /game/{game_ref}/ask-any.
 9. Otherwise choose one move from allowed_moves.
-10. POST /api/game/{game_ref}/move.
+10. POST /game/{game_ref}/move.
 11. On network errors, back off and poll again.

--- a/blog/2026-03-31_bot-registration-flow/submit-move.http
+++ b/blog/2026-03-31_bot-registration-flow/submit-move.http
@@ -1,4 +1,4 @@
-POST /api/game/K2Q9MJ/move
+POST /game/K2Q9MJ/move
 Authorization: Bearer ksbot_<token-id>.<token-secret>
 Content-Type: application/json
 


### PR DESCRIPTION
## Summary
- update the public bot guide to use prefix-free `api.kriegspiel.org` examples
- align the included HTTP snippets and runtime loop with the current bot repos
- clarify that `/api/...` belongs to the browser app ingress, not external bot clients

## Validation
- `npm run lint:markdown`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`
- `npm run lint:links`
