### PR TITLE
Clarify leaderboard API path

### DIFF
--- a/docs/landing-leaderboard-content.md
+++ b/docs/landing-leaderboard-content.md
@@ -11,7 +11,7 @@ This document records how ks-home Slice 920 surfaces integrate with content cont
 
 ## Leaderboard
 
-- Leaderboard data is API-backed (`/api/leaderboard`) and not sourced from markdown content.
+- Leaderboard data is API-backed (`/leaderboard` on `api.kriegspiel.org`) and not sourced from markdown content.
 - Content contract influence is route and metadata consistency from Slice 910.
 - Stale-data UX threshold: 15 minutes (`updatedAt` based).
 


### PR DESCRIPTION
## Summary
- updates the leaderboard integration note to refer to the prefix-free `/leaderboard` route on `api.kriegspiel.org`

## Validation
- `git diff --check`
- remote validation pending before merge

## Deployment
- rebuild ks-home content after merge if needed