### PR TITLE
Clarify Swart 1086 solution continuations

### DIFF
--- a/blog/2026-05-13_la-scacchiera-invisibile-problems/README.md
+++ b/blog/2026-05-13_la-scacchiera-invisibile-problems/README.md
@@ -424,11 +424,7 @@ Solution: `1.Rb5`. Non-silent: `2.Kxb5#` after `cxb5`, or `2.Re5#` after `Nxc7`.
 
 Diagram FEN: `4R2B/Q2R1r2/1b6/1K1Nr3/nP1k2n1/1P1p1B2/3P4/8 w - - 0 1`
 
-Solution: `1.Rc8`.
-
-Eastern rules: non-silent, `2.dxc3#` after `Nc3`, or `2.Rc4#` after `Rxf3`, `Rxd7`, or `Bxa7`. If `Any?` is "Yes," `2.dxe3#` after `Ne3`, `sor 2.Qa1#` after `Nc5`, `sor 2.Rc4#` after `Rf6`, `Rg7`, `Nf6`, `Nf2`, `Nh2`, or `Nh6`, `sor 2.Ne7#` after `Bc5`. If `Any?` is "No," `2.Qxb6#` after `Nb2`.
-
-Western rules: with zero possible captures, `2.Qxb6#` after `Nb2`; with one possible capture, `2.dxc3#` after `Nc3`, or `2.Rxd5#` after `Rxd5`, or `2.Qa1#` after `Nc5`, `sor 2.Rc4#` after `Rxf3`, `Rxd7`, `Rf6`, `Rg7`, `Nf6`, `Nf2`, `Nh2`, or `Nh6`; with two possible captures, `2.dxe3#` after `Ne3`, `sor 2.Ne7#` after `Bc5`.
+Solution: `1.Rc8`. The Eastern and Western rule continuations are both part of the solution. Under Eastern rules, the non-silent continuations are `2.dxc3#` after `Nc3`, or `2.Rc4#` after `Rxf3`, `Rxd7`, or `Bxa7`. If `Any?` is "Yes," `2.dxe3#` after `Ne3`, `sor 2.Qa1#` after `Nc5`, `sor 2.Rc4#` after `Rf6`, `Rg7`, `Nf6`, `Nf2`, `Nh2`, or `Nh6`, `sor 2.Ne7#` after `Bc5`. If `Any?` is "No," `2.Qxb6#` after `Nb2`. Under Western rules, with zero possible captures, `2.Qxb6#` follows `Nb2`; with one possible capture, `2.dxc3#` after `Nc3`, or `2.Rxd5#` after `Rxd5`, or `2.Qa1#` after `Nc5`, `sor 2.Rc4#` after `Rxf3`, `Rxd7`, `Rf6`, `Rg7`, `Nf6`, `Nf2`, `Nh2`, or `Nh6`; with two possible captures, `2.dxe3#` after `Ne3`, `sor 2.Ne7#` after `Bc5`.
 
 ### 7.2.4 - Swart 1204
 


### PR DESCRIPTION
## Summary
- folds the Swart 1086 Eastern and Western continuations into the `Solution:` paragraph
- makes clear that both rule-system continuations belong to the hidden solution block in the generated blog page

## Rationale
The Swart 1086 entry previously rendered only `1.Rc8` inside the solution block while the Eastern and Western continuation text appeared as ordinary visible prose. Those continuations are part of the solution.

## Tests
- `npm run validate:frontmatter`
- `npm run lint:markdown`
- `KS_CONTENT_PATH=/home/ubuntu/dev/kriegspiel/_wroktrees/content-swart-1086-solution npm run content:schema:check` from `ks-home`
- `KS_CONTENT_PATH=/home/ubuntu/dev/kriegspiel/_wroktrees/content-swart-1086-solution npm run build` from `ks-home`
- `KS_CONTENT_PATH=/home/ubuntu/dev/kriegspiel/_wroktrees/content-swart-1086-solution npm run test:e2e:blog-changelog` from `ks-home`
- HTML check: Swart 1086 Eastern/Western continuation text renders inside one `<details class="solution-block">`

Known unrelated failure:
- `KS_CONTENT_PATH=/home/ubuntu/dev/kriegspiel/_wroktrees/content-swart-1086-solution npm run test:snippets` from `ks-home` fails because `scripts/test-blog-snippet-includes.mjs` still expects `https://api.kriegspiel.org/api/auth/bots/register` while current content uses the prefix-free public API path.

## Deployment Notes
Content-only change. No runtime service restart or version bump required; deploy via the normal `ks-home` static site refresh after merge.

Verified commit: db976ae