### PR TITLE
Lowercase kriegspiel in Darkboard post title

### DIFF
--- a/blog/2026-05-18_darkboard-kriegspiel-engine-review/README.md
+++ b/blog/2026-05-18_darkboard-kriegspiel-engine-review/README.md
@@ -1,5 +1,5 @@
 ---
-title: "Darkboard, Kriegspiel, and the path to a new bot"
+title: "Darkboard, kriegspiel, and the path to a new bot"
 slug: "darkboard-kriegspiel-engine-review"
 summary: "A detailed review of the public Darkboard papers, tournament record, source-code availability, rule-set target, and a proposed Python implementation plan."
 publishedAt: "2026-05-18"


### PR DESCRIPTION
Summary:
- Lowercase "kriegspiel" in the Darkboard blog post title frontmatter.

Rationale:
- Match the requested title casing: "Darkboard, kriegspiel, and the path to a new bot".

Tests:
- npm run validate:frontmatter
- npm run lint:markdown
- git diff --check

Deployment notes:
- Content-only change; no runtime or API version bump.
- Requires the usual ks-home content refresh/deploy to appear on kriegspiel.org.