### PR TITLE
Document online ruleset adaptations

### DIFF
--- a/rules/berkeley.md
+++ b/rules/berkeley.md
@@ -3,14 +3,14 @@ title: "Berkeley kriegspiel rules"
 slug: "berkeley"
 summary: "Classic referee calls: No/Nonsense, capture square, directional checks."
 publishedAt: "2026-03-27"
-updatedAt: "2026-04-12"
+updatedAt: "2026-05-22"
 author: "Kriegspiel Team"
 tags: ["rules", "berkeley"]
 draft: false
 lifecycle: published
-version: "1.0.0"
-revision: "rules-berkeley-r2"
-lastReviewedAt: "2026-04-12"
+version: "1.0.1"
+revision: "rules-berkeley-r3"
+lastReviewedAt: "2026-05-22"
 changelogSlug: "2026-03-27-slice-940-trust-discoverability"
 ---
 ## I. Introduction:
@@ -74,6 +74,12 @@ In fact, all of the above combinations of material can be used to force mate in 
 For the purpose of the checkmate problems we provide, positions with material forced checkmates (including epsilon checkmates) are considered to be immediate checkmate positions. To ensure that the opposing king cannot immediately capture the checkmating material, we only declare these positions to be checkmates when the player's king is protecting said material. For example, if a player can certainly reduce a position to KQvK with her king protecting her queen in one move, this is considered a forced checkmate in one move.
 
 *Taken from [w01lfe's Berkeley rules](http://w01fe.com/berkeley/kriegspiel/rules.html).*
+
+---
+
+## Kriegspiel.org online implementation note
+
+The Berkeley text above intentionally excludes ordinary chess repetition and fifty-move draws. Kriegspiel.org follows that interpretation for Berkeley play, with one online-engine addition: a technical long-game cap for reversible play can declare a draw to keep games finite.
 
 ---
 

--- a/rules/english.md
+++ b/rules/english.md
@@ -3,14 +3,14 @@ title: "English kriegspiel rules"
 slug: "english"
 summary: "The Gambit Club English rules: three boards, umpire-controlled legality, capture-square announcements, directional checks, and the classic Any? question."
 publishedAt: "2026-04-28"
-updatedAt: "2026-04-28"
+updatedAt: "2026-05-22"
 author: "Kriegspiel Team"
 tags: ["rules", "english", "historical"]
 draft: false
 lifecycle: published
-version: "1.0.0"
-revision: "rules-english-r1"
-lastReviewedAt: "2026-04-28"
+version: "1.0.1"
+revision: "rules-english-r2"
+lastReviewedAt: "2026-05-22"
 ---
 
 These are the English rules enforced at the Gambit Club in London, as communicated by Miss E. C. Price and published in F. Dickens and G. White, *Chess in Bedfordshire*, Whitehead and Miller, Leeds, 1933.
@@ -60,6 +60,12 @@ These are the English rules enforced at the Gambit Club in London, as communicat
 13. The umpire shall not communicate or indicate to either of the players any detail or particular of the position of the pieces or the play except those permitted by the foregoing rules.
 
 14. The player that deliberately views the umpire's or his opponent's board and men shall forfeit the game.
+
+---
+
+## Kriegspiel.org online implementation note
+
+The draw clauses above preserve the historical Gambit Club text. Kriegspiel.org currently uses a shared online endgame policy for English games: checkmate, stalemate, insufficient material, and a technical long-game cap for reversible play. The site does not currently implement the special Gambit Club repeated-two-move draw clause as a separate rule.
 
 ## Source note
 

--- a/rules/rand.md
+++ b/rules/rand.md
@@ -3,14 +3,14 @@ title: "RAND"
 slug: "rand"
 summary: "J. D. Williams's 1950 RAND reference: pawn-try squares, typed captures, promotion announcements, and rebuff counts."
 publishedAt: "2026-04-26"
-updatedAt: "2026-04-26"
+updatedAt: "2026-05-22"
 author: "Kriegspiel Team"
 tags: ["rules", "rand", "historical"]
 draft: false
 lifecycle: published
-version: "1.0.1"
-revision: "rules-rand-r2"
-lastReviewedAt: "2026-04-26"
+version: "1.0.2"
+revision: "rules-rand-r3"
+lastReviewedAt: "2026-05-22"
 ---
 
 Standard chess rules apply, with the following additions and elucidations.
@@ -78,5 +78,11 @@ Standard chess rules apply, with the following additions and elucidations.
 19. It is considered ethical for a player to capitalize on blunders and all unsolicited information received from the referee and kibitzers. A player may solicit "information" from his opponent or otherwise heckle.
 
 20. For ladder games, the stalemate rule is currently modified: the stalemated player loses.
+
+---
+
+## Kriegspiel.org online implementation note
+
+The RAND rules allow a player to demand the count of the opponent's previous rebuffs or "no" answers. On Kriegspiel.org, RAND rebuffs are public in the referee log, so the count is visible from the log rather than exposed as a separate player action.
 
 *Original source: J. D. Williams, "Kriegsspiel rules at RAND", 1950. Via Paolo Ciancarini's [La Scacchiera Invisibile](https://www.cs.unibo.it/~paolo.ciancarini/wwwpages/chesssite/kriegspiel/scacchierainvisibile.pdf).*

--- a/rules/wild16.md
+++ b/rules/wild16.md
@@ -3,14 +3,14 @@ title: "Wild 16 / ICC kriegspiel rules"
 slug: "wild16"
 summary: "Detailed ICC-style kriegspiel rules: illegal attempts stay private, captures are typed, and pawn tries are announced as a count."
 publishedAt: "2026-03-27"
-updatedAt: "2026-04-19"
+updatedAt: "2026-05-22"
 author: "Kriegspiel Team"
 tags: ["rules", "wild16", "wild-16"]
 draft: false
 lifecycle: published
-version: "1.0.0"
-revision: "rules-wild16-r3"
-lastReviewedAt: "2026-04-19"
+version: "1.0.1"
+revision: "rules-wild16-r4"
+lastReviewedAt: "2026-05-22"
 changelogSlug: "2026-03-27-slice-940-trust-discoverability"
 ---
 Wild 16 is the Internet Chess Club version of Kriegspiel: chess with hidden information. Each player sees only their own pieces. The referee or server sees the full position and decides whether attempted moves are legal.
@@ -160,6 +160,12 @@ The game ends by normal chess conditions, including checkmate, stalemate, resign
 The referee or server determines checkmate and stalemate from the true hidden position.
 
 A player does not need to know the full position for checkmate or stalemate to be declared.
+
+---
+
+## Kriegspiel.org online implementation note
+
+The historical ICC-style rule above includes normal chess repetition and fifty-move draws. Kriegspiel.org currently uses a shared online endgame policy for Wild 16: checkmate, stalemate, insufficient material, and a technical long-game cap for reversible play. The rules engine does not currently offer player claims for threefold repetition or the fifty-move rule, and it does not apply automatic fivefold-repetition or seventy-five-move FIDE draws.
 
 ## 12. Observing and review
 


### PR DESCRIPTION
## Summary
- Add Kriegspiel.org online implementation notes to Berkeley, English, RAND, and Wild 16 rules pages.
- Clarify online endgame handling and RAND rebuff-count visibility through the referee log.
- Update affected rules page metadata versions, revisions, and review dates.

## Rationale
The historical rules text and the online engine behavior are intentionally close but not identical in a few places. These notes make the online adaptation explicit for readers of the public rules pages.

## Tests
- npm run lint:markdown
- npm run validate:frontmatter
- npm run validate:content-policy
- npm run lint:links
- git diff --check
- ks-home validation against this content branch:
  - KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-online-rules-notes npm run build
  - KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-online-rules-notes npm run content:schema:check
  - KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-online-rules-notes npm run content:source-contract:check
  - KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-online-rules-notes npm run test:smoke -- --routes=/rules/berkeley,/rules/wild16,/rules/rand,/rules/english
  - KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-online-rules-notes npm run routes:validate

## Deployment notes
Content-only change. Refresh ks-home static output after merge so kriegspiel.org/rules/* reflects the updated content.