### PR TITLE
Place source notes before online implementation notes

### DIFF
--- a/rules/english.md
+++ b/rules/english.md
@@ -8,8 +8,8 @@ author: "Kriegspiel Team"
 tags: ["rules", "english", "historical"]
 draft: false
 lifecycle: published
-version: "1.0.1"
-revision: "rules-english-r2"
+version: "1.0.2"
+revision: "rules-english-r3"
 lastReviewedAt: "2026-05-22"
 ---
 
@@ -61,14 +61,14 @@ These are the English rules enforced at the Gambit Club in London, as communicat
 
 14. The player that deliberately views the umpire's or his opponent's board and men shall forfeit the game.
 
----
-
-## Kriegspiel.org online implementation note
-
-The draw clauses above preserve the historical Gambit Club text. Kriegspiel.org currently uses a shared online endgame policy for English games: checkmate, stalemate, insufficient material, and a technical long-game cap for reversible play. The site does not currently implement the special Gambit Club repeated-two-move draw clause as a separate rule.
-
 ## Source note
 
 Original source: F. Dickens and G. White, *Chess in Bedfordshire*, Whitehead and Miller, Leeds, 1933, communicated by Miss E. C. Price from the Gambit Club in London.
 
 This transcription follows Appendix A, "Kriegspiel Rules at The Gambit", in Gian Piero Favini's [The dark side of the board: advances in chess Kriegspiel](https://www.cs.unibo.it/cianca/wwwpages/chesssite/favini2.pdf).
+
+---
+
+## Kriegspiel.org online implementation note
+
+The draw clauses above preserve the historical Gambit Club text. Kriegspiel.org currently uses a shared online endgame policy for English games: checkmate, stalemate, insufficient material, and a technical long-game cap for reversible play. The site does not currently implement the special Gambit Club repeated-two-move draw clause as a separate rule.

--- a/rules/rand.md
+++ b/rules/rand.md
@@ -8,8 +8,8 @@ author: "Kriegspiel Team"
 tags: ["rules", "rand", "historical"]
 draft: false
 lifecycle: published
-version: "1.0.2"
-revision: "rules-rand-r3"
+version: "1.0.3"
+revision: "rules-rand-r4"
 lastReviewedAt: "2026-05-22"
 ---
 
@@ -79,10 +79,10 @@ Standard chess rules apply, with the following additions and elucidations.
 
 20. For ladder games, the stalemate rule is currently modified: the stalemated player loses.
 
+*Original source: J. D. Williams, "Kriegsspiel rules at RAND", 1950. Via Paolo Ciancarini's [La Scacchiera Invisibile](https://www.cs.unibo.it/~paolo.ciancarini/wwwpages/chesssite/kriegspiel/scacchierainvisibile.pdf).*
+
 ---
 
 ## Kriegspiel.org online implementation note
 
 The RAND rules allow a player to demand the count of the opponent's previous rebuffs or "no" answers. On Kriegspiel.org, RAND rebuffs are public in the referee log, so the count is visible from the log rather than exposed as a separate player action.
-
-*Original source: J. D. Williams, "Kriegsspiel rules at RAND", 1950. Via Paolo Ciancarini's [La Scacchiera Invisibile](https://www.cs.unibo.it/~paolo.ciancarini/wwwpages/chesssite/kriegspiel/scacchierainvisibile.pdf).*

--- a/rules/wild16.md
+++ b/rules/wild16.md
@@ -8,8 +8,8 @@ author: "Kriegspiel Team"
 tags: ["rules", "wild16", "wild-16"]
 draft: false
 lifecycle: published
-version: "1.0.1"
-revision: "rules-wild16-r4"
+version: "1.0.2"
+revision: "rules-wild16-r5"
 lastReviewedAt: "2026-05-22"
 changelogSlug: "2026-03-27-slice-940-trust-discoverability"
 ---
@@ -161,12 +161,6 @@ The referee or server determines checkmate and stalemate from the true hidden po
 
 A player does not need to know the full position for checkmate or stalemate to be declared.
 
----
-
-## Kriegspiel.org online implementation note
-
-The historical ICC-style rule above includes normal chess repetition and fifty-move draws. Kriegspiel.org currently uses a shared online endgame policy for Wild 16: checkmate, stalemate, insufficient material, and a technical long-game cap for reversible play. The rules engine does not currently offer player claims for threefold repetition or the fifty-move rule, and it does not apply automatic fivefold-repetition or seventy-five-move FIDE draws.
-
 ## 12. Observing and review
 
 Rated Kriegspiel games should not be observable while in progress, because an observer who sees both sides could provide outside information.
@@ -237,3 +231,9 @@ Cincinnati style gives only the existence of a pawn capture.
 The original Chessclub help page is no longer live, so retrieving it now requires the Wayback Machine or other archived copies. It was originally stored at `www.chessclub.com/help/Kriegspiel`.
 
 This version is adapted from archived copies of that help page and from [La Scacchiera Invisibile (PDF)](https://www.cs.unibo.it/~paolo.ciancarini/wwwpages/chesssite/kriegspiel/scacchierainvisibile.pdf).
+
+---
+
+## Kriegspiel.org online implementation note
+
+The historical ICC-style rule above includes normal chess repetition and fifty-move draws. Kriegspiel.org currently uses a shared online endgame policy for Wild 16: checkmate, stalemate, insufficient material, and a technical long-game cap for reversible play. The rules engine does not currently offer player claims for threefold repetition or the fifty-move rule, and it does not apply automatic fivefold-repetition or seventy-five-move FIDE draws.


### PR DESCRIPTION
## Summary
- Move English, RAND, and Wild 16 source notes before the horizontal rule that introduces the Kriegspiel.org online implementation notes.
- Keep the implementation notes after the source-backed historical/reference rules text.
- Update affected page version/revision metadata.

## Rationale
The source notes describe the historical/reference rules above them, while the online implementation note is Kriegspiel.org-specific commentary. This order makes that boundary clearer.

## Tests
Content repo:
- npm run lint:markdown
- npm run validate:frontmatter
- npm run validate:content-policy
- npm run lint:links
- git diff --check

ks-home validation against this content branch:
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-source-before-implementation-note npm run build
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-source-before-implementation-note npm run content:schema:check
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-source-before-implementation-note npm run test:smoke -- --routes=/rules/english,/rules/wild16,/rules/rand,/rules/berkeley

## Deployment notes
Content-only change. Refresh ks-home static output after merge.