### PR TITLE
Add content publication notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Kriegspiel Content
+
+This repository holds the editable public content consumed by the Kriegspiel
+site. Published and draft blog entries live under `blog/`, public rules pages
+under `rules/`, and singleton site pages under `site/`.
+
+## Proposed Blog Publications
+
+- Source mirror and archive storage: propose keeping local copies of key
+  Kriegspiel papers, books, and manuscripts so the site is not dependent on
+  doubtful links to semi-alive external websites. Before any mirrored copy is
+  published or served, figure out the license and rights status for each item
+  and record whether it is public domain, openly licensed, permission-granted,
+  citation-only, or still needs review.
+- History of Kriegspiel rulesets: trace the major rules traditions and compare
+  how they handle announcements, illegal attempts, pawn tries, `Any?`, captures,
+  promotion, stalemate, and the current platform rulesets.
+- Books and manuscripts available: publish an annotated guide to Kriegspiel
+  books, pamphlets, manuscripts, problem collections, and archival scans, with
+  author, date, source, rights notes, and local-copy availability.


### PR DESCRIPTION
## Summary
- Add a root README for the content repository.
- Capture proposed blog/publication topics: source mirror/archive storage with rights review, history of Kriegspiel rulesets, and available books/manuscripts.

## Rationale
This records the editorial backlog item about preserving key Kriegspiel papers, books, and manuscripts without relying only on fragile external links, while making the license/rights review requirement explicit before any mirrored files are served.

## Tests
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`

Verified commit: `4b8f5b7 Add content publication notes`

## Deployment Notes
Docs-only content-repo note. No version bump, service restart, or public-site deployment required.