### PR TITLE
Specify online long-game cap

### DIFF
--- a/rules/berkeley.md
+++ b/rules/berkeley.md
@@ -8,8 +8,8 @@ author: "Kriegspiel Team"
 tags: ["rules", "berkeley"]
 draft: false
 lifecycle: published
-version: "1.0.1"
-revision: "rules-berkeley-r3"
+version: "1.0.2"
+revision: "rules-berkeley-r4"
 lastReviewedAt: "2026-05-22"
 changelogSlug: "2026-03-27-slice-940-trust-discoverability"
 ---
@@ -79,7 +79,7 @@ For the purpose of the checkmate problems we provide, positions with material fo
 
 ## Kriegspiel.org online implementation note
 
-The Berkeley text above intentionally excludes ordinary chess repetition and fifty-move draws. Kriegspiel.org follows that interpretation for Berkeley play, with one online-engine addition: a technical long-game cap for reversible play can declare a draw to keep games finite.
+The Berkeley text above intentionally excludes ordinary chess repetition and fifty-move draws. Kriegspiel.org follows that interpretation for Berkeley play, with one online-engine addition: if the half-move clock reaches 2,000 consecutive half-moves without a pawn move or capture, the game is declared drawn to keep games finite.
 
 ---
 

--- a/rules/english.md
+++ b/rules/english.md
@@ -8,8 +8,8 @@ author: "Kriegspiel Team"
 tags: ["rules", "english", "historical"]
 draft: false
 lifecycle: published
-version: "1.0.2"
-revision: "rules-english-r3"
+version: "1.0.3"
+revision: "rules-english-r4"
 lastReviewedAt: "2026-05-22"
 ---
 
@@ -71,4 +71,4 @@ This transcription follows Appendix A, "Kriegspiel Rules at The Gambit", in Gian
 
 ## Kriegspiel.org online implementation note
 
-The draw clauses above preserve the historical Gambit Club text. Kriegspiel.org currently uses a shared online endgame policy for English games: checkmate, stalemate, insufficient material, and a technical long-game cap for reversible play. The site does not currently implement the special Gambit Club repeated-two-move draw clause as a separate rule.
+The draw clauses above preserve the historical Gambit Club text. Kriegspiel.org currently uses a shared online endgame policy for English games: checkmate, stalemate, insufficient material, and a finite-game cap. If the half-move clock reaches 2,000 consecutive half-moves without a pawn move or capture, the game is declared drawn. The site does not currently implement the special Gambit Club repeated-two-move draw clause as a separate rule.

--- a/rules/wild16.md
+++ b/rules/wild16.md
@@ -8,8 +8,8 @@ author: "Kriegspiel Team"
 tags: ["rules", "wild16", "wild-16"]
 draft: false
 lifecycle: published
-version: "1.0.2"
-revision: "rules-wild16-r5"
+version: "1.0.3"
+revision: "rules-wild16-r6"
 lastReviewedAt: "2026-05-22"
 changelogSlug: "2026-03-27-slice-940-trust-discoverability"
 ---
@@ -236,4 +236,4 @@ This version is adapted from archived copies of that help page and from [La Scac
 
 ## Kriegspiel.org online implementation note
 
-The historical ICC-style rule above includes normal chess repetition and fifty-move draws. Kriegspiel.org currently uses a shared online endgame policy for Wild 16: checkmate, stalemate, insufficient material, and a technical long-game cap for reversible play. The rules engine does not currently offer player claims for threefold repetition or the fifty-move rule, and it does not apply automatic fivefold-repetition or seventy-five-move FIDE draws.
+The historical ICC-style rule above includes normal chess repetition and fifty-move draws. Kriegspiel.org currently uses a shared online endgame policy for Wild 16: checkmate, stalemate, insufficient material, and a finite-game cap. If the half-move clock reaches 2,000 consecutive half-moves without a pawn move or capture, the game is declared drawn. The rules engine does not currently offer player claims for threefold repetition or the fifty-move rule, and it does not apply automatic fivefold-repetition or seventy-five-move FIDE draws.


### PR DESCRIPTION
## Summary
- Replace the vague online long-game cap wording with the current 2,000 half-move rule.
- Apply the clarification to Berkeley, English, and Wild 16 rules notes.
- Bump the affected content document versions/revisions.

## Rationale
The rules pages should state the exact engine behavior: if the half-move clock reaches 2,000 consecutive half-moves without a pawn move or capture, the game is declared drawn to keep online games finite.

## Tests
- npm run lint:markdown
- npm run validate:frontmatter
- npm run validate:content-policy
- npm run lint:links
- git diff --check
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-specify-2000-rule npm run build (ks-home)
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-specify-2000-rule npm run content:schema:check (ks-home)
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-specify-2000-rule npm run test:smoke -- --routes=/rules/berkeley,/rules/english,/rules/wild16 (ks-home)
- rg -n "2,000|half-move clock|finite-game cap" dist/rules/berkeley/index.html dist/rules/english/index.html dist/rules/wild16/index.html (ks-home)

## Deployment Notes
Content-only change. Refresh ks-home content after merge; no backend, frontend app, or engine restart needed.