### PR TITLE
Add Berkeley problem database topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ under `rules/`, and singleton site pages under `site/`.
 - Books and manuscripts available: publish an annotated guide to Kriegspiel
   books, pamphlets, manuscripts, problem collections, and archival scans, with
   author, date, source, rights notes, and local-copy availability.
+- Berkeley problem database: explain Jason Wolfe and Stuart Russell's Berkeley
+  Kriegspiel problem set, how filtered PGN encodes player-perspective histories,
+  what the mate and near-miss instances test, and how the database could guide
+  platform benchmarks or future solver work.


### PR DESCRIPTION
## Summary
- Add the Berkeley problem database to the proposed blog publications list.
- Describe the angle around the Berkeley problem set, filtered PGN, mate and near-miss instances, and possible benchmark/solver use.

## Rationale
This records the Berkeley problem database as a standalone editorial candidate instead of only treating it as supporting material for broader ruleset or research posts.

## Tests
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`

Verified commit: `c9b888a`

## Deployment Notes
Docs-only content-repo note. No version bump, service restart, or public-site deployment required.