### PR TITLE
Draft proposed blog topics

### DIFF
--- a/blog/2026-05-23_berkeley-problem-database/README.md
+++ b/blog/2026-05-23_berkeley-problem-database/README.md
@@ -1,0 +1,175 @@
+---
+title: "The Berkeley Kriegspiel problem database"
+slug: "berkeley-problem-database"
+summary: "A draft guide to Jason Wolfe and Stuart Russell's Berkeley Kriegspiel problem database, filtered PGN records, and why the set matters for benchmarks and solver work."
+publishedAt: "2026-05-23"
+updatedAt: "2026-05-23"
+author: "Kriegspiel Team"
+tags: ["berkeley", "problems", "benchmarks"]
+draft: true
+lifecycle: draft
+---
+
+The Berkeley Kriegspiel problem database is one of the most practical public
+resources in the research trail around Jason Wolfe and Stuart Russell. It does
+something rare for hidden-information chess: it gives named problems, recorded
+histories, and a notation format that can preserve what a player knew, not only
+what was true on the hidden board.
+
+This draft explains what the database is, why filtered PGN matters, and how the
+problem set could guide future platform benchmarks or solver work.
+
+Primary starting points:
+
+- [Berkeley problem database](https://w01fe.com/berkeley/kriegspiel/problems.html)
+- [Berkeley rules](https://w01fe.com/berkeley/kriegspiel/rules.html)
+- [Berkeley PGN notation](https://w01fe.com/berkeley/kriegspiel/notation.html)
+- [Efficient Belief-State AND-OR Search, with Application to Kriegspiel](https://people.eecs.berkeley.edu/~russell/papers/ijcai05-krieg.pdf)
+
+## Why the database matters
+
+Most Kriegspiel sources explain ideas. The Berkeley database gives testable
+objects. That distinction matters because hidden-information claims are easy to
+state and hard to reproduce.
+
+If a paper says a method solves a problem, a reader needs to know the exact
+rules, the initial visible position, the hidden history, the referee messages,
+and the player's perspective. Ordinary chess notation is not enough, because an
+ordinary PGN record reveals too much.
+
+The Berkeley pages solve that by placing three things near each other:
+
+1. a concrete rules page
+2. a filtered PGN notation
+3. a database of problems
+
+Together, those sources make a small benchmark ecosystem.
+
+## Filtered PGN is the key idea
+
+In ordinary chess, a PGN game is a complete visible history. In Kriegspiel, that
+would leak information. The player on move does not know the opponent's pieces,
+the opponent's exact moves, or sometimes even why a try failed.
+
+Filtered PGN records the game from a player's perspective. It can preserve:
+
+- attempted moves
+- accepted moves
+- rejected illegal attempts
+- referee announcements
+- visible own-piece moves
+- hidden opponent movement as experienced by the player
+- check or capture information in the form the ruleset allows
+
+That makes filtered PGN a natural bridge between composed problems and software
+tests. A solver can be given the same information the player had, not the
+omniscient referee state.
+
+## What the problems test
+
+The database includes mate and near-miss instances. Both are useful.
+
+Mate problems test whether a method can find a forcing strategy under
+uncertainty. The strategy may need to branch on referee messages rather than on
+visible opponent moves. A correct solution is a policy, not just a line.
+
+Near-miss problems are just as important. They test whether a solver can avoid
+being fooled by a move that almost works but fails under one hidden reply or one
+referee response. In ordinary chess, a near-miss is often a tactical refutation.
+In Kriegspiel, it can be an information refutation: the player cannot tell which
+mate is needed at the decisive moment.
+
+This is exactly the kind of distinction a belief-state search algorithm should
+handle.
+
+## Relationship to Wolfe and Russell
+
+The database belongs beside Wolfe and Russell's Berkeley research line,
+especially the IJCAI 2005 paper on efficient belief-state AND-OR search. That
+paper frames Kriegspiel as a partially observable search problem, where a
+program must reason over sets of possible worlds and observation-conditioned
+plans.
+
+The problem database gives concrete cases where that framing can be tested.
+Instead of asking whether an engine plays good full games, one can ask whether
+it solves small, carefully shaped positions.
+
+That makes Berkeley complementary to Bologna. Bologna gives a broad trail
+toward practical Darkboard play, metapositions, MCTS, and ICC tournaments.
+Berkeley gives a tighter trail around rules, notation, problems, and
+belief-state search.
+
+## What the platform could do with it
+
+The database suggests several possible platform features:
+
+- import selected problems as static study pages
+- render filtered PGN as player-perspective replay
+- create backend tests for legal attempts and referee messages under Berkeley
+  rules
+- create solver benchmarks for `ks-game` or a future problem-solver package
+- compare Berkeley problems with English `Any?` problems from Anderson and
+  Ciancarini
+- use near-miss positions as regression tests for hidden-information safety
+
+The most immediate value is probably not a user-facing puzzle interface. It is
+a benchmark harness. A small set of imported Berkeley problems could become
+repeatable tests for:
+
+- ruleset fidelity
+- player projection
+- notation parsing
+- belief-state search
+- problem-solution validation
+
+## Import questions
+
+Before importing anything, the project needs to answer practical questions:
+
+- What rights apply to the problem database and notation?
+- Should imported problems preserve Berkeley labels exactly?
+- Should filtered PGN be stored as source material, parsed data, or both?
+- How much of the original hidden state is needed to validate a solution?
+- Should problem pages show only player-perspective information, or also a
+  referee view after the solution?
+- Do we need a dedicated `content/problems/` collection, or should problems
+  remain inside blog posts until the interface is designed?
+
+The answer may be phased. Start with a blog explanation and a few manually
+checked examples. Move to structured imports only after the notation and rights
+questions are settled.
+
+## A possible benchmark shape
+
+A future benchmark could represent each problem as:
+
+```yaml
+id: berkeley-example
+ruleset: berkeley
+source: "Berkeley Kriegspiel problem database"
+sourceUrl: "https://w01fe.com/berkeley/kriegspiel/problems.html"
+initialPerspective: white
+filteredPgn: "..."
+stipulation: "White to move and mate"
+expectedResult: forced-mate
+rightsStatus: needs-review
+```
+
+The benchmark runner would load the filtered history, reconstruct the player's
+information state, then ask a solver for a policy. The policy would be checked
+against all hidden states still compatible with the record.
+
+That last sentence is the hard part. It is also the reason the database is
+interesting.
+
+## Publication checklist
+
+- Verify the database contents and terminology directly against the Berkeley
+  pages.
+- Read the PGN notation page closely enough to summarize filtered records
+  accurately.
+- Pick one small example and explain why ordinary PGN would leak too much.
+- Decide whether to discuss import rights here or defer that to the source
+  mirror policy post.
+- Connect the post to future benchmark work without promising an implementation
+  schedule.

--- a/blog/2026-05-23_kriegspiel-books-manuscripts/README.md
+++ b/blog/2026-05-23_kriegspiel-books-manuscripts/README.md
@@ -1,0 +1,210 @@
+---
+title: "Books and manuscripts for Kriegspiel"
+slug: "kriegspiel-books-manuscripts"
+summary: "A draft annotated guide to Kriegspiel books, pamphlets, manuscripts, problem collections, archival scans, and catalogue-only sources."
+publishedAt: "2026-05-23"
+updatedAt: "2026-05-23"
+author: "Kriegspiel Team"
+tags: ["books", "history", "research"]
+draft: true
+lifecycle: draft
+---
+
+The Kriegspiel bibliography is not just a list of AI papers. Books, pamphlets,
+manuscripts, problem collections, and archival scans preserve parts of the game
+that papers often treat as background: table rules, referee language, composed
+problems, endgame technique, and the culture of playing in the dark.
+
+This draft is an annotated guide to the book-length and manuscript-like sources
+worth tracking first.
+
+## H. Cayley: Kriegspiel, or, The Chess War Game
+
+H. Cayley's *Kriegspiel, or, The Chess War Game* belongs to the game's early
+English-language trail. Catalogue records usually place it around 1900 or 1905,
+which makes the exact date less important than the source's role: it sits near
+the period when Kriegspiel was moving from a chess curiosity into a describable
+variant with its own rules literature.
+
+For the site, this should begin as a catalogue entry. Before linking or serving
+any scan, we need to verify the edition, date, and public-domain status.
+
+Draft notes:
+
+- likely source type: pamphlet or booklet
+- current access: catalogue and library discovery first
+- rights status: needs review
+- site value: origin trail, early rule language, bibliographic anchor
+
+## Gerald Frank Anderson: Are There Any? A Chess Problem Book
+
+Gerald Frank Anderson's *Are There Any? A Chess Problem Book* is one of the most
+important sources for the English problem tradition. The title captures the
+signature question of that tradition: before moving, White can ask whether any
+legal pawn captures exist.
+
+Anderson is important because he treats Kriegspiel as a problemist's medium.
+The solution to a problem is not merely a visible-board move. It is a procedure
+that survives hidden replies, referee answers, failed tries, captures, checks,
+and deductions.
+
+Later sources cite the date slightly differently, often 1958 or 1959. A cautious
+entry should record both until the physical title page is checked.
+
+Draft notes:
+
+- likely source type: problem book
+- current access: catalogue and secondhand discovery
+- rights status: likely citation-only unless permission or public-domain review
+  says otherwise
+- site value: English rules, `Are there any?`, composed-problem culture
+
+## Lloyd Shapley: The Invisible Chessboard
+
+Lloyd S. Shapley's *The Invisible Chessboard* is an unpublished manuscript and
+problem collection, publicly preserved through the Harlow Shapley Project. It is
+one of the strongest bridges between Kriegspiel, game theory, RAND/UCLA
+intellectual history, and the problem tradition.
+
+Shapley's importance is not that he produced a tidy publication cluster. It is
+that his work appears around several later sources: Thomas Ferguson's UCLA
+papers, Alexander Matros's retrospective, and the Harlow Shapley Project's rules
+and demonstration materials.
+
+Draft notes:
+
+- likely source type: unpublished manuscript / problem collection
+- current access: public archival scan
+- rights status: needs review before mirroring
+- site value: RAND/UCLA bridge, Shapley problems, hidden-information theory
+
+Primary starting point:
+
+- [The Invisible Chessboard](https://harlowshapley.org/s/Kriegspiel-rules-and-Lloyd-Shapley-demo.pdf)
+
+## David H. Li: Kriegspiel: Chess Under Uncertainty
+
+David H. Li's *Kriegspiel: Chess Under Uncertainty* is the main modern
+English-language book devoted directly to Kriegspiel as a playable chess
+variant. It belongs beside the academic sources because it speaks to practical
+play, strategy, and the experience of reasoning without seeing the opponent's
+pieces.
+
+The book is especially useful for readers who want more than a paper trail. AI
+papers often explain why Kriegspiel is computationally hard. A practical book
+can explain how the game feels and why humans keep playing it.
+
+Draft notes:
+
+- likely source type: modern book
+- current access: catalogue and used-book discovery
+- rights status: citation-only unless permission is obtained
+- site value: practical play, strategy, reader-friendly bridge
+
+## David H. Li: Chess Detective
+
+Li's *Chess Detective: Kriegspiel Strategies, Endgames and Problems* is a
+companion source focused on deduction, technique, endgames, and composed
+positions. It should be treated together with *Kriegspiel: Chess Under
+Uncertainty* but described separately, because its problem-and-endgame emphasis
+may be more directly useful for site features.
+
+Draft notes:
+
+- likely source type: modern book / problem and strategy collection
+- current access: catalogue and used-book discovery
+- rights status: citation-only unless permission is obtained
+- site value: endgames, problem material, practical deduction
+
+## Paolo Ciancarini: La Scacchiera Invisibile
+
+Paolo Ciancarini's *La Scacchiera Invisibile* is a book manuscript in progress,
+listed from his University of Bologna Kriegspiel page. The PDF itself is marked
+Version 0.9 and dated 11 May 2004.
+
+This source is unusually rich. It connects history, rules, research context, and
+a large problem collection. It also preserves Anderson problems, Henk Swart
+problems, and other composed material in Italian. The existing site post
+"Problems from La Scacchiera Invisibile" already translates and organizes the
+problem chapter, which makes the manuscript a living source for the project
+rather than a bibliographic footnote.
+
+Draft notes:
+
+- likely source type: manuscript / book in progress
+- current access: public author-hosted PDF
+- rights status: needs review before mirroring
+- site value: Bologna bridge, problem collection, rules/history context
+
+Primary starting point:
+
+- [La Scacchiera Invisibile](https://www.cs.unibo.it/~paolo.ciancarini/wwwpages/chesssite/kriegspiel/scacchierainvisibile.pdf)
+
+## Gian Piero Favini: The dark side of the board
+
+Favini's doctoral thesis, *The dark side of the board: advances in chess
+Kriegspiel*, is not a book in the commercial sense, but it is one of the most
+important long-form sources in the field. It gives the best public synthesis of
+the Bologna research program around metapositions, Darkboard, ICC play, MCTS,
+and implementation architecture.
+
+This is the source to read when a short paper is too compressed. It ties the
+algorithmic story to actual software structure and tournament play.
+
+Draft notes:
+
+- likely source type: doctoral thesis
+- current access: University of Bologna repository
+- rights status: needs review before mirroring
+- site value: Darkboard architecture, Bologna synthesis, implementation context
+
+Primary starting point:
+
+- [The dark side of the board](https://amsdottorato.unibo.it/id/eprint/2403/)
+
+## How the guide should be organized
+
+The final post should not pretend that all sources are equally accessible. It
+should separate:
+
+- public full text
+- public metadata only
+- catalogue-only records
+- archival scans
+- uncertain or conflicting date records
+- sources needing rights review
+
+That structure helps readers and protects the project. Readers learn where to
+start. Maintainers learn what can be mirrored, what can only be cited, and what
+still needs investigation.
+
+## Working table
+
+| Source | Date | Access | Rights status | Best use |
+| --- | --- | --- | --- | --- |
+| Cayley, *Kriegspiel, or, The Chess War Game* | ca. 1900/1905 | Catalogue first | Needs review | Origin trail |
+| Anderson, *Are There Any?* | 1958/1959 | Catalogue / used copies | Citation-only until reviewed | English problem tradition |
+| Shapley, *The Invisible Chessboard* | 1987 | Public archival scan | Needs review | RAND/UCLA bridge |
+| Li, *Kriegspiel: Chess Under Uncertainty* | 1994 | Catalogue / used copies | Citation-only | Practical play |
+| Li, *Chess Detective* | 1995 | Catalogue / used copies | Citation-only | Problems, endgames, strategy |
+| Ciancarini, *La Scacchiera Invisibile* | 2004 | Public author-hosted PDF | Needs review | Bologna history and problems |
+| Favini, *The dark side of the board* | 2010 | Public repository record | Needs review | Darkboard and implementation |
+
+## Open questions
+
+- Which catalogue source should be treated as canonical for each book?
+- Can we verify Cayley's exact date and publisher from a scan or library copy?
+- Should the site include availability notes such as "used copies sometimes
+  appear" or avoid marketplace guidance?
+- Should unpublished manuscripts be listed with books, or in a separate
+  "manuscripts and scans" section?
+- Which sources deserve direct permission requests first?
+
+## Publication checklist
+
+- Verify every bibliographic record against a primary catalogue or title page.
+- Add ISBN, OCLC, DOI, or repository handles where available.
+- Record rights status in a structured registry if that exists before
+  publication.
+- Decide whether this guide should link to the source-mirror policy post.
+- Add a short reading order for newcomers.

--- a/blog/2026-05-23_kriegspiel-ruleset-history/README.md
+++ b/blog/2026-05-23_kriegspiel-ruleset-history/README.md
@@ -1,0 +1,180 @@
+---
+title: "A history of Kriegspiel rulesets"
+slug: "kriegspiel-ruleset-history"
+summary: "A draft tour through major Kriegspiel rules traditions, from English problem rules to Berkeley, ICC Wild 16, Cincinnati, RAND, and the current platform variants."
+publishedAt: "2026-05-23"
+updatedAt: "2026-05-23"
+author: "Kriegspiel Team"
+tags: ["rules", "history", "variants"]
+draft: true
+lifecycle: draft
+---
+
+Kriegspiel is not one rulebook. It is a family of hidden-information chess
+traditions that agree on the broad idea and then disagree about the referee.
+What does the referee announce? Are illegal attempts private? Can a player ask
+whether any pawn captures exist? Does a capture reveal the square, the piece
+type, both, or neither? What happens at stalemate? Those details change the
+game.
+
+This draft maps the rules traditions that matter most for the platform and the
+research literature: English problem rules, Berkeley, ICC Wild 16, Cincinnati,
+RAND, and the platform's newer `berkeley_any` and `crazykrieg` variants.
+
+## The core problem
+
+All Kriegspiel rulesets start from the same dramatic constraint. Each player
+sees their own pieces, not the opponent's. A referee knows the full position and
+decides whether attempted moves are legal. The rest of the game is shaped by
+how much the referee says.
+
+That means ruleset design is really information design. A small announcement
+can turn an impossible deduction into a forced mate. A hidden illegal attempt
+can make one version feel like silent search and another feel like public
+probing. A pawn-try rule can decide whether a problem has a unique solution.
+
+## English rules and the problem tradition
+
+The English problem tradition is closely associated with Gerald Frank
+Anderson's *Are There Any? A Chess Problem Book*. Its famous question is right
+there in the title: before moving, a player may ask whether there are any legal
+pawn captures.
+
+In composed problems, that question is not a side feature. It is often the
+mechanism that lets White distinguish hidden black replies. Some problems use a
+failed pawn capture as a test, then finish with a mate that only works because
+the answer revealed the structure of the position.
+
+This tradition gives Kriegspiel a puzzle language. The core question is not
+only "what move wins?" but "what sequence of questions, tries, and deductions
+wins no matter what the hidden reply was?"
+
+## Berkeley rules
+
+The Berkeley line around Jason Wolfe and Stuart Russell gives a modern,
+well-documented ruleset for research. Wolfe's Berkeley pages include:
+
+- [Berkeley Kriegspiel rules](https://w01fe.com/berkeley/kriegspiel/rules.html)
+- [Berkeley problem database](https://w01fe.com/berkeley/kriegspiel/problems.html)
+- [Berkeley PGN notation](https://w01fe.com/berkeley/kriegspiel/notation.html)
+
+Berkeley is especially important because it couples a rules page with a problem
+database and notation. That makes it more than a way to play. It is a benchmark
+environment: positions, hidden histories, and player-perspective records can be
+named and tested.
+
+On this platform, `berkeley` is the base version. `berkeley_any` extends that
+family with an explicit `Any?` interaction, making it closer to the problem
+tradition without becoming identical to every English-rule convention.
+
+## ICC Wild 16
+
+The Internet Chess Club ruleset, also known as Wild 16, is the most important
+computer-tournament ruleset. The ICGA Computer Olympiad used this family for
+the Kriegspiel events won by Darkboard in 2006 and 2009.
+
+The important Wild 16 features are:
+
+- failed illegal attempts are private
+- captures announce the square and whether the captured unit was a pawn or a
+  piece
+- check announcements identify the line or type of check
+- pawn-try information is counted for the next player
+- there is no Berkeley-style `Any?` question
+
+Wild 16 matters because the strongest public computer-player trail points
+toward it. Darkboard, Favini's thesis, and the Bologna MCTS papers all make the
+most sense when read against the ICC/Computer Olympiad environment.
+
+## Cincinnati
+
+Cincinnati is another historically important rules family, but the name can be
+slippery. Some public research text uses "Cincinnati style" while also
+describing behavior that, in this platform, is closer to Wild 16.
+
+For platform purposes, `cincinnati` has a distinct identity:
+
+- illegal attempts are public
+- captures announce square and pawn or piece type
+- the next turn has a binary pawn-capture availability signal
+
+Public illegal attempts make the game feel very different. A player can learn
+not only from their own rejected moves, but from the opponent's failed probes.
+That makes the board more talkative and changes the value of speculative tries.
+
+## RAND
+
+RAND rules are important partly because of Lloyd Shapley. Shapley's
+*The Invisible Chessboard* and related UCLA material sit in a tradition where
+problem logic, game theory, and hidden-information chess meet.
+
+On this platform, `rand` has several defining features:
+
+- source-square pawn-try announcements
+- typed pawn or piece captures
+- public illegal attempts
+- promotion announcements
+- stalemate is a loss
+
+RAND is one of the clearest examples of how referee language changes the
+mathematics of the game. A source-square pawn-try announcement is more
+informative than a bare yes/no answer, and stalemate-as-loss changes endgame
+incentives.
+
+## English and CrazyKrieg
+
+The platform's `english` ruleset uses `Any?` with one required pawn-capture try
+after a positive answer. If that try is illegal, the player is released and may
+make any legal move. This captures an important problem-tradition rhythm:
+question, forced test, then deduction.
+
+`crazykrieg` adds crazyhouse-like reserves to the hidden-information setting.
+Its information design is deliberately explicit in some places and hidden in
+others:
+
+- reserves are public
+- drop squares are hidden
+- captures announce exact reserve identity
+- the same one-failed-pawn-try release after `Any?` applies
+
+CrazyKrieg is not just chess Kriegspiel with drops. Public reserves create a
+new public resource economy, while hidden drop squares keep the central
+uncertainty intact.
+
+## Comparison table
+
+| Ruleset | Illegal attempts | Pawn-try / Any? | Capture announcements | Stalemate |
+| --- | --- | --- | --- | --- |
+| English problem tradition | Varies by source, often used as hidden tests | `Are there any?` is central | Depends on convention | Usually orthodox unless specified |
+| Berkeley | Private from opponent | No `Any?` in base platform variant | Berkeley-specific referee messages | Orthodox unless specified |
+| Berkeley Any | Private from opponent | `Any?` supported | Berkeley-family messages | Orthodox unless specified |
+| Wild 16 | Private from opponent | Counted next-turn pawn tries | Square plus pawn/piece type | Orthodox unless specified |
+| Cincinnati | Public | Binary next-turn pawn-capture availability | Square plus pawn/piece type | Orthodox unless specified |
+| RAND | Public | Source-square pawn-try announcements | Square plus pawn/piece type | Loss |
+| English | Private from opponent | `Any?` plus required pawn-capture try | English-family messages | Orthodox unless specified |
+| CrazyKrieg | Private from opponent | `Any?` plus required pawn-capture try | Exact reserve identity | Orthodox unless specified |
+
+This table is intentionally a draft. Each row should be checked against the
+platform rules pages and source traditions before publication.
+
+## Why this history matters for the site
+
+Rulesets are not cosmetic variants. They determine what kind of reasoning a
+player can do, what a bot can infer, what a composed problem means, and whether
+an old paper is actually comparable to a modern platform game.
+
+A Darkboard-style bot should start from Wild 16 because the Computer Olympiad
+trail points there. Berkeley problems should be evaluated under Berkeley rules
+because their notation and database assume that environment. Anderson-style
+problems should not be casually translated into another ruleset without noting
+which `Any?` and capture-announcement assumptions changed.
+
+## Publication checklist
+
+- Verify every platform ruleset row against the current rule documents.
+- Add direct citations for Berkeley, ICC/Wild 16, Ciancarini, Anderson, Shapley,
+  and Ferguson.
+- Decide whether to include examples from existing platform games.
+- Add one worked position showing how a different announcement changes the
+  solution.
+- Make the comparison table precise enough to be used as operator memory.

--- a/blog/2026-05-23_source-mirror-archive-storage/README.md
+++ b/blog/2026-05-23_source-mirror-archive-storage/README.md
@@ -1,0 +1,150 @@
+---
+title: "Source mirrors, archives, and rights review"
+slug: "source-mirror-archive-storage"
+summary: "A draft plan for preserving Kriegspiel papers, books, manuscripts, and supporting links without publishing material before its rights status is clear."
+publishedAt: "2026-05-23"
+updatedAt: "2026-05-23"
+author: "Kriegspiel Team"
+tags: ["research", "archives", "rights"]
+draft: true
+lifecycle: draft
+---
+
+Kriegspiel research lives in a fragile public record. Some sources sit in
+ordinary journal archives. Others live on old university pages, personal pages,
+scan repositories, tournament sites, library catalogues, or PDFs linked from
+pages that have not changed in years. A reader can still reconstruct the field,
+but only by trusting a trail of links that may not stay alive.
+
+This post is a draft preservation policy for that trail. The goal is simple:
+make Kriegspiel sources easier to find without quietly republishing material we
+do not have the right to serve.
+
+## Why mirrors are tempting
+
+Several sources are foundational enough that losing access would harm future
+work on the site:
+
+| Source family | Examples | Why preservation matters |
+| --- | --- | --- |
+| Bologna papers and manuscripts | Paolo Ciancarini's Kriegspiel page, *La Scacchiera Invisibile*, Gian Piero Favini's thesis | This is the broadest public research program around Darkboard, metapositions, MCTS, and endgame analysis. |
+| Berkeley materials | Jason Wolfe's rules, problem database, PGN notation, and Wolfe/Russell papers | These sources define a clean rules and benchmark tradition that is useful for modern platform tests. |
+| UCLA and Shapley materials | Thomas Ferguson's papers and Lloyd Shapley's *The Invisible Chessboard* | These preserve the mathematical and problem-composition tradition behind several endgame claims. |
+| Tournament records | ICGA pages for the 2006 and 2009 Kriegspiel Olympiad events | These are the best public anchors for Darkboard's competitive record. |
+| Books and catalogued pamphlets | Cayley, Anderson, David H. Li, and related problem collections | These are harder to find and often exist only as catalogue records or used copies. |
+
+The preservation case is strongest for source metadata: title, author, year,
+venue, current URL, catalogue records, access notes, and rights status. The case
+for serving a local copy depends on the rights review.
+
+## The rights-first rule
+
+Local storage is not the same as public serving. We should separate four states:
+
+| Status | Meaning | Site behavior |
+| --- | --- | --- |
+| `citation-only` | We know the source exists, but do not have rights to mirror it. | Link to the official or catalogue page only. |
+| `public-domain` | The work is old enough or otherwise confirmed to be public domain in the relevant jurisdictions. | A local copy may be served with a rights note. |
+| `open-license` | The work has an explicit license allowing redistribution. | A local copy may be served with license attribution. |
+| `permission-granted` | The rights holder explicitly allows Kriegspiel.org to host a copy. | A local copy may be served with permission details recorded. |
+| `needs-review` | We have not finished the rights review. | Do not serve a local copy. |
+
+The site should never use "it was easy to download" as a proxy for permission.
+Academic PDFs, personal scans, and institutional repository files can be
+publicly accessible while still carrying restrictions on redistribution.
+
+## What to store before publication
+
+The first useful artifact is a source registry, not a pile of PDFs. A registry
+entry should capture:
+
+- title
+- author or editor
+- year or best-known date range
+- publication venue or source type
+- canonical URL
+- backup discovery URLs
+- catalogue identifiers such as DOI, WorldCat, institutional handle, or ISBN
+- current access status
+- rights status
+- local-copy status
+- review notes
+- last verified date
+
+That registry could live in `content` as structured metadata and feed future
+public source pages. It could also remain private until the site has a clear
+display design.
+
+## Source types need different treatment
+
+Journal papers should usually point to DOI, publisher, conference, or author
+pages. If an author-hosted PDF is available, link to it, but do not mirror it
+unless the license or author permission allows that.
+
+University-hosted theses and institutional repository records are often good
+candidates for stable links. They still need rights notes before mirroring.
+Favini's thesis, for example, has a public University of Bologna repository
+record and a downloadable PDF. That makes it a strong citation source, but the
+rights metadata still matters.
+
+Manuscripts and archival scans need the most care. Shapley's *The Invisible
+Chessboard* is publicly available through the Harlow Shapley Project, but a
+local mirror should still record who owns the scan and what permission applies.
+
+Books, pamphlets, and problem collections should start as annotated catalogue
+entries. Cayley, Anderson, and David H. Li are valuable even when the public web
+only provides library or sales records. For those, the first site feature should
+be discovery, not reproduction.
+
+## Candidate registry fields
+
+```yaml
+id: favini-dark-side-board
+title: "The dark side of the board: advances in chess Kriegspiel"
+authors:
+  - "Gian Piero Favini"
+year: 2010
+type: thesis
+canonicalUrl: "https://amsdottorato.unibo.it/id/eprint/2403/"
+accessUrls:
+  - "https://amsdottorato.unibo.it/id/eprint/2403/1/favini_gianpiero_tesi.pdf"
+rightsStatus: needs-review
+localCopy: none
+lastVerified: "2026-05-23"
+notes: "Public institutional repository record; review repository rights before mirroring."
+```
+
+The registry should prefer stable identifiers over convenience links. DOI,
+publisher record, institutional handle, WorldCat record, and author page are all
+more useful than an arbitrary copied PDF path when they exist.
+
+## Proposed workflow
+
+1. Build a private or draft source registry from the existing research-map
+   citations.
+2. Mark every item `needs-review` by default.
+3. Promote obvious catalogue-only items to `citation-only`.
+4. Review candidate public-domain items separately, especially older pamphlets.
+5. Ask permission for sources that are central, fragile, and not otherwise
+   mirrorable.
+6. Serve local copies only after the rights status is recorded.
+7. Add a public "source notes" section to each mirrored item explaining why it
+   can be hosted.
+
+## Open questions
+
+- Should the registry live in `content` as a public draft, or should rights
+  review begin in a private operator note?
+- Do we want local copies for preservation only, or visible download pages?
+- Which jurisdiction should the public-domain review use as the minimum bar?
+- How should we record author-granted permission so future maintainers can
+  audit it?
+- Should mirrored files live in `content`, `ks-home`, object storage, or a
+  separate archive repository?
+
+## A cautious first milestone
+
+The safest first milestone is an annotated source index with no local serving.
+That already improves the public record: readers get stable citations, source
+types, date notes, and access notes in one place. Mirroring can come later,
+source by source, after the rights work is done.


### PR DESCRIPTION
## Summary
- Add draft blog entries for all proposed publication topics currently tracked in the content README.
- Drafted posts for source mirrors/archive storage, ruleset history, books and manuscripts, and the Berkeley problem database.
- Keep every new entry unpublished with `draft: true` and `lifecycle: draft`.

## Rationale
This turns the proposed topic backlog into concrete article drafts while preserving the production contract that drafts do not publish unless explicitly enabled in preview builds.

## Tests
Content repo:
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`

Website behavior check from `ks-home` against this content worktree:
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-draft-proposed-blog-topics npm run build`
- `rg` check confirmed draft slugs absent from the normal production build output.
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-draft-proposed-blog-topics KS_PREVIEW_DRAFTS=true npm run build`
- `rg` check confirmed draft slugs present in preview output.

Verified commit: `9eda481`

## Deployment Notes
Draft-only content change. No version bump, service restart, or public-site deployment required because production excludes `draft: true` entries by default.