### PR TITLE
Spread draft blog schedule

### DIFF
--- a/blog/2026-06-23_source-mirror-archive-storage/README.md
+++ b/blog/2026-06-23_source-mirror-archive-storage/README.md
@@ -2,8 +2,8 @@
 title: "Source mirrors, archives, and rights review"
 slug: "source-mirror-archive-storage"
 summary: "A draft plan for preserving Kriegspiel papers, books, manuscripts, and supporting links without publishing material before its rights status is clear."
-publishedAt: "2026-05-23"
-updatedAt: "2026-05-23"
+publishedAt: "2026-06-23"
+updatedAt: "2026-06-23"
 author: "Kriegspiel Team"
 tags: ["research", "archives", "rights"]
 draft: true

--- a/blog/2026-07-23_kriegspiel-ruleset-history/README.md
+++ b/blog/2026-07-23_kriegspiel-ruleset-history/README.md
@@ -2,8 +2,8 @@
 title: "A history of Kriegspiel rulesets"
 slug: "kriegspiel-ruleset-history"
 summary: "A draft tour through major Kriegspiel rules traditions, from English problem rules to Berkeley, ICC Wild 16, Cincinnati, RAND, and the current platform variants."
-publishedAt: "2026-05-23"
-updatedAt: "2026-05-23"
+publishedAt: "2026-07-23"
+updatedAt: "2026-07-23"
 author: "Kriegspiel Team"
 tags: ["rules", "history", "variants"]
 draft: true

--- a/blog/2026-08-23_kriegspiel-books-manuscripts/README.md
+++ b/blog/2026-08-23_kriegspiel-books-manuscripts/README.md
@@ -2,8 +2,8 @@
 title: "Books and manuscripts for Kriegspiel"
 slug: "kriegspiel-books-manuscripts"
 summary: "A draft annotated guide to Kriegspiel books, pamphlets, manuscripts, problem collections, archival scans, and catalogue-only sources."
-publishedAt: "2026-05-23"
-updatedAt: "2026-05-23"
+publishedAt: "2026-08-23"
+updatedAt: "2026-08-23"
 author: "Kriegspiel Team"
 tags: ["books", "history", "research"]
 draft: true

--- a/blog/2026-09-23_berkeley-problem-database/README.md
+++ b/blog/2026-09-23_berkeley-problem-database/README.md
@@ -2,8 +2,8 @@
 title: "The Berkeley Kriegspiel problem database"
 slug: "berkeley-problem-database"
 summary: "A draft guide to Jason Wolfe and Stuart Russell's Berkeley Kriegspiel problem database, filtered PGN records, and why the set matters for benchmarks and solver work."
-publishedAt: "2026-05-23"
-updatedAt: "2026-05-23"
+publishedAt: "2026-09-23"
+updatedAt: "2026-09-23"
 author: "Kriegspiel Team"
 tags: ["berkeley", "problems", "benchmarks"]
 draft: true


### PR DESCRIPTION
## Summary
- Move the proposed draft blog entries from a shared May date into monthly draft slots.
- Schedule source mirrors/archive storage for June 23, ruleset history for July 23, books and manuscripts for August 23, and Berkeley problem database for September 23.
- Keep all entries as `draft: true` / `lifecycle: draft`.

## Rationale
This gives the draft backlog a clearer publication cadence across June, July, August, and September while preserving the unpublished production behavior for drafts.

## Tests
Content repo:
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`

Website behavior check from `ks-home` against this content worktree:
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-spread-draft-blog-dates npm run build`
- `rg` check confirmed draft slugs absent from the normal production build output.
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-spread-draft-blog-dates KS_PREVIEW_DRAFTS=true npm run build`
- `rg` check confirmed draft slugs present in preview output.

Verified commit: `45383fa`

## Deployment Notes
Draft-only schedule change. No version bump, service restart, or public-site deployment required because production excludes `draft: true` entries by default.