### PR TITLE
Mark Darkboard blog post as draft

### DIFF
--- a/blog/2026-05-18_darkboard-kriegspiel-engine-review/README.md
+++ b/blog/2026-05-18_darkboard-kriegspiel-engine-review/README.md
@@ -6,8 +6,8 @@ publishedAt: "2026-05-18"
 updatedAt: "2026-05-24"
 author: "Kriegspiel Team"
 tags: ["research", "bots", "implementation", "darkboard"]
-draft: false
-lifecycle: published
+draft: true
+lifecycle: draft
 ---
 
 Darkboard is the best-known historical computer player for chess Kriegspiel.


### PR DESCRIPTION
## Summary
- mark the Darkboard blog post as a draft
- move its lifecycle back from published to draft

## Rationale
The post should be unpublished for now while preserving the article body for later revision.

## Tests
- npm run validate:frontmatter
- npm run validate:content-policy
- npm run lint:markdown
- npm run lint:links
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-unpublish-darkboard-post npm run build (ks-home)
- explicit rendered-output check confirmed the Darkboard slug is absent from blog index, RSS, Atom, sitemap, and generated routes
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-unpublish-darkboard-post npm run content:schema:check (ks-home)
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-unpublish-darkboard-post npm run feeds:generate -- --check (ks-home)
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-unpublish-darkboard-post npm run sitemap:generate -- --check (ks-home)
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-unpublish-darkboard-post npm run seo:validate -- --routes=/,/blog,/blog/archive,/changelog,/rules (ks-home)
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-unpublish-darkboard-post npm run test:e2e:blog-changelog (ks-home)

## Deployment notes
After merge, refresh the static site from the updated content checkout so the generated blog pages, feed files, and sitemap drop the post.