### PR TITLE
Simplify illegal attempts comparison

### DIFF
--- a/blog/2026-08-23_kriegspiel-ruleset-history/README.md
+++ b/blog/2026-08-23_kriegspiel-ruleset-history/README.md
@@ -145,14 +145,14 @@ uncertainty intact.
 
 | Ruleset | Illegal attempts | Pawn-try / Any? | Capture announcements | Other rules |
 | --- | --- | --- | --- | --- |
-| English problem tradition | Public illegal announcement in the Gambit Club tradition | `Are there any?` is central | Depends on convention | Problem texts may depend on specific `Any?`, try, and stalemate conventions |
-| Berkeley | Public rejection; attempted move hidden | No `Any?` in base platform variant | Capture square only | -- |
-| Berkeley Any | Public rejection; attempted move hidden | `Any?` supported; positive answer requires a legal pawn capture | Capture square only | -- |
-| Wild 16 | Private rejection; only the player hears it | Counted next-turn pawn tries | Square plus pawn/piece type | -- |
-| Cincinnati | Public `Illegal` or `Nonsense` | Binary next-turn pawn-capture availability | Square plus pawn/piece type | -- |
-| RAND | Public rebuffs | Source-square pawn-try announcements | Square plus pawn/piece type | Stalemated player loses; promotions announced, but not the promoted piece |
+| English problem tradition | Public illegal announcement | `Are there any?` is central | Depends on convention | Problem texts may depend on specific `Any?`, try, and stalemate conventions |
+| Berkeley | Public illegal announcement | No `Any?` in base platform variant | Capture square only | -- |
+| Berkeley Any | Public illegal announcement | `Any?` supported; positive answer requires a legal pawn capture | Capture square only | -- |
+| Wild 16 | Private illegal announcement | Counted next-turn pawn tries | Square plus pawn/piece type | -- |
+| Cincinnati | Public illegal announcement | Binary next-turn pawn-capture availability | Square plus pawn/piece type | -- |
+| RAND | Public illegal announcement | Source-square pawn-try announcements | Square plus pawn/piece type | Stalemated player loses; promotions announced, but not the promoted piece |
 | English | Public illegal announcement | `Any?` plus one required pawn-capture try | Capture square only | -- |
-| CrazyKrieg | Public rejection; attempted move hidden | `Any?` plus one required pawn-capture try | Capture square plus exact reserve identity | Crazyhouse rules with public reserves and hidden drop squares |
+| CrazyKrieg | Public illegal announcement | `Any?` plus one required pawn-capture try | Capture square plus exact reserve identity | Crazyhouse rules with public reserves and hidden drop squares |
 
 This table is intentionally a draft. Each row should be checked against the
 platform rules pages and source traditions before publication.


### PR DESCRIPTION
## Summary
- normalize the comparison table illegal-attempts column to `Public illegal announcement` for every row except Wild 16
- use `Private illegal announcement` for Wild 16

## Rationale
The table should emphasize the one meaningful distinction instead of repeating ruleset-specific phrasing for the same public behavior.

## Tests
- npm run lint:markdown
- npm run lint:links
- npm run validate:frontmatter
- npm run validate:content-policy
- npm run build:content-index

Verified commit: 666c102

## Deployment notes
Content-only draft update. No version bump or runtime restart required; ks-home refresh can pick up the content source change.