### PR TITLE
Add RSS to canonical footer links

### DIFF
--- a/site/footer/README.md
+++ b/site/footer/README.md
@@ -3,7 +3,7 @@ title: "Footer"
 slug: "footer"
 summary: "Canonical footer content and link grouping for kriegspiel.org."
 publishedAt: "2026-03-29"
-updatedAt: "2026-04-28"
+updatedAt: "2026-05-25"
 author: "Kriegspiel Team"
 tags: ["site", "footer", "navigation"]
 draft: false
@@ -24,6 +24,7 @@ draft: false
 # Communication
 - [Blog](/blog)
 - [Changelog](/changelog)
+- [RSS](/feed.xml)
 - [About](/about)
 
 # Policy


### PR DESCRIPTION
Summary
- Add RSS to the canonical Communication footer between Changelog and About.
- Refresh the footer content updatedAt date.

Rationale
The public site and app footer should both expose the updates feed in the same Communication link order.

Tests
- npm run lint:markdown
- npm run validate:frontmatter
- npm run lint:links
- npm run validate:content-policy

Deployment notes
Content-only change. Merge before refreshing ks-home so kriegspiel.org renders the canonical RSS link; no service restart by itself.

Verified commit: 67c7efb1a178cd0f45a5bdbb9178aace9a223130