### PR TITLE
Clarify English en passant in rules history draft

### DIFF
--- a/blog/2026-08-23_kriegspiel-ruleset-history/README.md
+++ b/blog/2026-08-23_kriegspiel-ruleset-history/README.md
@@ -128,6 +128,13 @@ after a positive answer. If that try is illegal, the player is released and may
 make any legal move. This captures an important problem-tradition rhythm:
 question, forced test, then deduction.
 
+Its capture announcements are mostly spare: ordinary captures announce the
+capture square without naming the capturing or captured man. En passant is the
+important exception in the current platform rules. Later English/Eastern
+summaries explicitly announce that the capture was en passant, and
+Kriegspiel.org follows that convention by announcing the capturing pawn's
+landing square rather than the square of the pawn removed from the board.
+
 `crazykrieg` adds crazyhouse-like reserves to the hidden-information setting.
 Its information design is deliberately explicit in some places and hidden in
 others:
@@ -151,7 +158,7 @@ uncertainty intact.
 | Wild 16 | Private illegal announcement | Counted next-turn pawn tries | Square plus pawn/piece type | -- |
 | Cincinnati | Public illegal announcement | Binary next-turn pawn-capture availability | Square plus pawn/piece type | -- |
 | RAND | Public illegal announcement | Source-square pawn-try announcements | Square plus pawn/piece type | Stalemated player loses; promotions announced, but not the promoted piece |
-| English | Public illegal announcement | `Any?` plus one required pawn-capture try | Capture square only | -- |
+| English | Public illegal announcement | `Any?` plus one required pawn-capture try | Ordinary captures announce square only; en passant is announced explicitly on the landing square | -- |
 | CrazyKrieg | Public illegal announcement | `Any?` plus one required pawn-capture try | Capture square plus exact reserve identity | Crazyhouse rules with public reserves and hidden drop squares |
 
 This table is intentionally a draft. Each row should be checked against the


### PR DESCRIPTION
## Summary
- Update the drafted ruleset-history blogpost to distinguish ordinary English capture-square announcements from the English en-passant exception.
- Update the draft comparison table so English en passant is described as explicitly announced on the landing square.

## Rationale
The draft previously said platform English captures were simply “capture square only,” which is now stale after the engine/rules update for English en-passant announcements.

## Tests
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`

## Deployment Notes
Draft content only; no runtime deploy or site refresh required until the draft is published.