### PR TITLE
Shorten illegal-attempt labels in rules history draft

### DIFF
--- a/blog/2026-08-23_kriegspiel-ruleset-history/README.md
+++ b/blog/2026-08-23_kriegspiel-ruleset-history/README.md
@@ -152,14 +152,14 @@ uncertainty intact.
 
 | Ruleset | Illegal attempts | Pawn-try / Any? | Capture announcements | Other rules |
 | --- | --- | --- | --- | --- |
-| English problem tradition | Public illegal announcement | `Are there any?` is central | Depends on convention | Problem texts may depend on specific `Any?`, try, and stalemate conventions |
-| Berkeley | Public illegal announcement | No `Any?` in base platform variant | Capture square only | -- |
-| Berkeley Any | Public illegal announcement | `Any?` supported; positive answer requires a legal pawn capture | Capture square only | -- |
-| Wild 16 | Private illegal announcement | Counted next-turn pawn tries | Square plus pawn/piece type | -- |
-| Cincinnati | Public illegal announcement | Binary next-turn pawn-capture availability | Square plus pawn/piece type | -- |
-| RAND | Public illegal announcement | Source-square pawn-try announcements | Square plus pawn/piece type | Stalemated player loses; promotions announced, but not the promoted piece |
-| English | Public illegal announcement | `Any?` plus one required pawn-capture try | Ordinary captures announce square only; en passant is announced explicitly on the landing square | -- |
-| CrazyKrieg | Public illegal announcement | `Any?` plus one required pawn-capture try | Capture square plus exact reserve identity | Crazyhouse rules with public reserves and hidden drop squares |
+| English problem tradition | Public | `Are there any?` is central | Depends on convention | Problem texts may depend on specific `Any?`, try, and stalemate conventions |
+| Berkeley | Public | No `Any?` in base platform variant | Capture square only | -- |
+| Berkeley Any | Public | `Any?` supported; positive answer requires a legal pawn capture | Capture square only | -- |
+| Wild 16 | Private | Counted next-turn pawn tries | Square plus pawn/piece type | -- |
+| Cincinnati | Public | Binary next-turn pawn-capture availability | Square plus pawn/piece type | -- |
+| RAND | Public | Source-square pawn-try announcements | Square plus pawn/piece type | Stalemated player loses; promotions announced, but not the promoted piece |
+| English | Public | `Any?` plus one required pawn-capture try | Ordinary captures announce square only; en passant is announced explicitly on the landing square | -- |
+| CrazyKrieg | Public | `Any?` plus one required pawn-capture try | Capture square plus exact reserve identity | Crazyhouse rules with public reserves and hidden drop squares |
 
 This table is intentionally a draft. Each row should be checked against the
 platform rules pages and source traditions before publication.


### PR DESCRIPTION
## Summary
- Change the ruleset-history draft table's Illegal attempts column to use only `Public` or `Private`.

## Tests
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`

## Deployment Notes
Draft content only; no runtime deploy or public site refresh required.