### PR TITLE
Rename package metadata to ks-content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kriegspiel Content
+# Kriegspiel Content (`ks-content`)
 
 This repository holds the editable public content consumed by the Kriegspiel
 site. Published and draft blog entries live under `blog/`, public rules pages

--- a/blog/2026-07-23_source-mirror-archive-storage/README.md
+++ b/blog/2026-07-23_source-mirror-archive-storage/README.md
@@ -71,7 +71,7 @@ entry should capture:
 - review notes
 - last verified date
 
-That registry could live in `content` as structured metadata and feed future
+That registry could live in `ks-content` as structured metadata and feed future
 public source pages. It could also remain private until the site has a clear
 display design.
 
@@ -133,13 +133,13 @@ more useful than an arbitrary copied PDF path when they exist.
 
 ## Open questions
 
-- Should the registry live in `content` as a public draft, or should rights
+- Should the registry live in `ks-content` as a public draft, or should rights
   review begin in a private operator note?
 - Do we want local copies for preservation only, or visible download pages?
 - Which jurisdiction should the public-domain review use as the minimum bar?
 - How should we record author-granted permission so future maintainers can
   audit it?
-- Should mirrored files live in `content`, `ks-home`, object storage, or a
+- Should mirrored files live in `ks-content`, `ks-home`, object storage, or a
   separate archive repository?
 
 ## A cautious first milestone

--- a/blog/2026-10-23_berkeley-problem-database/README.md
+++ b/blog/2026-10-23_berkeley-problem-database/README.md
@@ -132,7 +132,7 @@ Before importing anything, the project needs to answer practical questions:
 - How much of the original hidden state is needed to validate a solution?
 - Should problem pages show only player-perspective information, or also a
   referee view after the solution?
-- Do we need a dedicated `content/problems/` collection, or should problems
+- Do we need a dedicated `ks-content/problems/` collection, or should problems
   remain inside blog posts until the interface is designed?
 
 The answer may be phased. Start with a blog explanation and a few manually

--- a/docs/content-source-contract.md
+++ b/docs/content-source-contract.md
@@ -1,6 +1,6 @@
 # Content Source Contract (Slice 910)
 
-Kriegspiel/content is the source of truth for website collections consumed by ks-home.
+Kriegspiel/ks-content is the source of truth for website collections consumed by ks-home.
 
 ## Collections
 

--- a/docs/editorial-pipeline.md
+++ b/docs/editorial-pipeline.md
@@ -24,4 +24,4 @@ npm run build:content-index
 1. Run all content checks above.
 2. Verify slug uniqueness.
 3. Link to related changelog/blog entry when relevant.
-4. Merge content PR; website regeneration check must pass.
+4. Merge the `ks-content` PR; website regeneration check must pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "kriegspiel-content",
-  "version": "0.1.0",
+  "name": "ks-content",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kriegspiel-content",
-      "version": "0.1.0"
+      "name": "ks-content",
+      "version": "0.1.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "kriegspiel-content",
+  "name": "ks-content",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "lint:markdown": "node scripts/lint-markdown.mjs",


### PR DESCRIPTION
## Summary
- Update the private package name to `ks-content` and bump it to `0.1.1`.
- Update content docs and draft references that named the repo as `content`.

## Rationale
The GitHub repository has been renamed from `Kriegspiel/content` to `Kriegspiel/ks-content` for naming consistency across the Kriegspiel workspace.

## Tests
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`
- Verified commit: `7746d9a`

## Deployment notes
Content-only metadata/docs change. Publishing still requires a `ks-home` refresh if public content output changes.
