### PR TITLE
Remove Dutch from shared footer

### DIFF
--- a/site/footer/README.md
+++ b/site/footer/README.md
@@ -3,7 +3,7 @@ title: "Footer"
 slug: "footer"
 summary: "Canonical footer content and link grouping for kriegspiel.org."
 publishedAt: "2026-03-29"
-updatedAt: "2026-05-25"
+updatedAt: "2026-05-26"
 author: "Kriegspiel Team"
 tags: ["site", "footer", "navigation"]
 draft: false
@@ -19,7 +19,6 @@ draft: false
 - [RAND](/rules/rand)
 - [English](/rules/english)
 - [CrazyKrieg](/rules/crazykrieg)
-- [Dutch](/rules/dutch)
 - [Comparison](/rules/comparison/)
 
 # Communication


### PR DESCRIPTION
## Summary
- Remove the Dutch ruleset link from the canonical shared footer content.
- Update the footer content `updatedAt` date to 2026-05-26.

## Rationale
Dutch is currently an incomplete historical/composition note, so it should not be promoted in the shared footer for either the public site or the app. The rules page remains available for direct/reference use.

## Tests
- `npm run validate:frontmatter`
- `npm run lint:markdown`
- `npm run lint:links`
- Cross-repo verification with `ks-home` and `ks-web-app` using commit `344053edd8d4efe0c1e469d7b1144e70eb85ef7e` as the content source.

## Deployment Notes
- Refresh/rebuild `ks-home` after merging so the public footer picks up the shared content change.
- Rebuild/redeploy `ks-web-app` after merging because the app footer consumes this shared footer content at build time.
