### PR TITLE
Simplify Dutch row in ruleset history table

### DIFF
--- a/blog/2026-08-23_kriegspiel-ruleset-history/README.md
+++ b/blog/2026-08-23_kriegspiel-ruleset-history/README.md
@@ -180,7 +180,7 @@ uncertainty intact.
 | Ruleset | Illegal attempts | Pawn-try / Any? | Capture announcements | Other rules |
 | --- | --- | --- | --- | --- |
 | English problem tradition | Public | `Are there any?` is central | Depends on convention | Problem texts may depend on specific `Any?`, try, and stalemate conventions |
-| Dutch | Not fully sourced | Known Swart example uses `Any?`; full pawn-try convention is not sourced | Capture square plus whether the capturing man was a pawn or a piece | Historical composition note only; not playable online |
+| Dutch | No source | Announce if capture was done by pawn or piece after an `Any?` | Announce if capture was done by pawn or piece after an `Any?` and a square | -- |
 | Berkeley | Public | No `Any?` in base platform variant | Capture square only | -- |
 | Berkeley Any | Public | `Any?` supported; positive answer requires a legal pawn capture | Capture square only | -- |
 | Wild 16 | Private | Counted next-turn pawn tries | Square plus pawn/piece type | -- |


### PR DESCRIPTION
## Summary
- simplify the Dutch row in the ruleset-history comparison table
- keep the row explicit that illegal-attempt sourcing is absent and other rules are unspecified

## Rationale
The table should stay compact and avoid over-explaining the incomplete Dutch convention details in the comparison view.

## Tests
- npm run lint:markdown
- npm run lint:links
- npm run validate:frontmatter
- npm run validate:content-policy
- npm run build:content-index

## Deployment notes
Content-only draft-post update. Requires normal ks-home content refresh after merge; no runtime service restart expected.