### PR TITLE
Remove English problem tradition from ruleset table

### DIFF
--- a/blog/2026-08-23_kriegspiel-ruleset-history/README.md
+++ b/blog/2026-08-23_kriegspiel-ruleset-history/README.md
@@ -179,7 +179,6 @@ uncertainty intact.
 
 | Ruleset | Illegal attempts | Pawn-try / Any? | Capture announcements | Other rules |
 | --- | --- | --- | --- | --- |
-| English problem tradition | Public | `Are there any?` is central | Depends on convention | Problem texts may depend on specific `Any?`, try, and stalemate conventions |
 | Berkeley | Public | No `Any?` in base platform variant | Capture square only | -- |
 | Berkeley Any | Public | `Any?` supported; positive answer requires a legal pawn capture | Capture square only | -- |
 | Wild 16 | Private | Counted next-turn pawn tries | Square plus pawn/piece type | -- |


### PR DESCRIPTION
## Summary
- Remove the `English problem tradition` row from the ruleset comparison table in the draft ruleset-history blog post.

## Rationale
- The English problem tradition is historical/compositional context, not a concrete ruleset row for the comparison table.
- The surrounding article context remains intact.

## Tests
- `npm run lint:markdown`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run lint:links`
- `npm run build:content-index`

## Version / Deployment
- No version bump: draft content-only edit, no runtime/API/package change.
- No service restart or live verification needed unless this draft is later published or the static site is refreshed.