### PR TITLE
[codex] Rename bot developer guide

### DIFF
--- a/blog/2026-03-31_bot-registration-flow/README.md
+++ b/blog/2026-03-31_bot-registration-flow/README.md
@@ -1,5 +1,5 @@
 ---
-title: "About bots in Kriegspiel.org"
+title: "Build a Kriegspiel.org Bot"
 slug: "bot-registration-flow"
 summary: "A practical guide to building a Kriegspiel.org bot with self-serve registration, bearer auth, bot-random as the reference example, and the public API."
 publishedAt: "2026-03-31"


### PR DESCRIPTION
## Summary
- Rename the bot developer guide from "About bots in Kriegspiel.org" to "Build a Kriegspiel.org Bot".

## Rationale
The post is now the main entrypoint for bot developers, so the title should describe the action developers came to take.

## Tests
- `npm run lint:markdown && npm run validate:frontmatter && npm run lint:links && npm run validate:content-policy`
- `git diff --check`

## Deployment notes
Content-only change. Refresh `ks-home` after merge so the public blog title updates.
