### PR TITLE
[codex] Use lowercase bot in guide title

### DIFF
--- a/blog/2026-03-31_bot-registration-flow/README.md
+++ b/blog/2026-03-31_bot-registration-flow/README.md
@@ -1,5 +1,5 @@
 ---
-title: "Build a Kriegspiel.org Bot"
+title: "Build a Kriegspiel.org bot"
 slug: "bot-registration-flow"
 summary: "A practical guide to building a Kriegspiel.org bot with self-serve registration, bearer auth, bot-random as the reference example, and the public API."
 publishedAt: "2026-03-31"


### PR DESCRIPTION
## Summary
- Change the bot guide title from "Build a Kriegspiel.org Bot" to "Build a Kriegspiel.org bot".

## Rationale
`bot` should read as a regular noun here rather than title case.

## Tests
- `npm run lint:markdown && npm run validate:frontmatter && npm run lint:links && npm run validate:content-policy`
- `git diff --check`

## Deployment notes
Content-only change. Refresh `ks-home` after merge.
