### PR TITLE
[codex] Publish Darkboard engine review

### DIFF
--- a/blog/2026-05-18_darkboard-kriegspiel-engine-review/README.md
+++ b/blog/2026-05-18_darkboard-kriegspiel-engine-review/README.md
@@ -2,12 +2,12 @@
 title: "Darkboard, kriegspiel, and the path to a new bot"
 slug: "darkboard-kriegspiel-engine-review"
 summary: "A concise review of the public Darkboard record, source-code availability, and the best first implementation path for a new Python bot."
-publishedAt: "2026-05-18"
+publishedAt: "2026-06-27"
 updatedAt: "2026-06-27"
 author: "Kriegspiel Team"
 tags: ["research", "bots", "implementation", "darkboard"]
-draft: true
-lifecycle: draft
+draft: false
+lifecycle: published
 ---
 
 Darkboard is the best-known historical computer player for chess Kriegspiel.


### PR DESCRIPTION
## Summary

- Publishes the Darkboard engine-review post by switching it from draft to published.
- Sets the public publish date to 2026-06-27 so the post appears as a current blog/RSS item.

## Rationale

The article has been reviewed and tightened, and is ready to appear on the public site.

## Tests

- `npm run lint:markdown`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run lint:links`
- `npm run build:content-index`
- `git diff --check`

## Deployment Notes

- Content-only publish in `ks-content`; no package version bump.
- After merge, refresh `ks-home` and verify the public blog page, RSS, Atom, and sitemap.