### PR TITLE
[codex] Remove duplicate footer GitHub link

### DIFF
--- a/site/footer/README.md
+++ b/site/footer/README.md
@@ -3,7 +3,7 @@ title: "Footer"
 slug: "footer"
 summary: "Canonical footer content and link grouping for kriegspiel.org."
 publishedAt: "2026-03-29"
-updatedAt: "2026-05-26"
+updatedAt: "2026-07-05"
 author: "Kriegspiel Team"
 tags: ["site", "footer", "navigation"]
 draft: false
@@ -37,5 +37,4 @@ draft: false
 
 # Social
 - [X.com](https://x.com/kriegspiel_org)
-- [GitHub](https://github.com/Kriegspiel)
 - [any@kriegspiel.org](mailto:any@kriegspiel.org)


### PR DESCRIPTION
## Summary
- Remove the duplicate GitHub link from the Social footer group.
- Keep GitHub in the Development footer group.
- Refresh the footer entry updatedAt date.

## Rationale
The footer had GitHub in both Development and Social/community-style groupings. This keeps the repository link in the developer-focused section while removing the duplicate community/social entry.

## Tests
- `npm run lint:markdown`
- `npm run validate:frontmatter`
- `npm run lint:links`

## Deployment Notes
Merge before or alongside the `ks-home` refresh and `ks-web-app` rebuild so both public surfaces consume the same footer content.

Verified commit: `90dcacc`