### PR TITLE
[codex] add platform playing guide

### DIFF
--- a/site/footer/README.md
+++ b/site/footer/README.md
@@ -3,14 +3,15 @@ title: "Footer"
 slug: "footer"
 summary: "Canonical footer content and link grouping for kriegspiel.org."
 publishedAt: "2026-03-29"
-updatedAt: "2026-05-26"
+updatedAt: "2026-07-05"
 author: "Kriegspiel Team"
 tags: ["site", "footer", "navigation"]
 draft: false
 ---
 # Game
-- [Leaderboard](/leaderboard)
 - [Play online](https://app.kriegspiel.org/)
+- [Playing here](/playing)
+- [Leaderboard](/leaderboard)
 
 # Rules
 - [Berkeley](/rules/berkeley)

--- a/site/footer/README.md
+++ b/site/footer/README.md
@@ -10,7 +10,7 @@ draft: false
 ---
 # Game
 - [Play online](https://app.kriegspiel.org/)
-- [Playing here](/playing)
+- [Playing guide](/playing)
 - [Leaderboard](/leaderboard)
 
 # Rules

--- a/site/playing/README.md
+++ b/site/playing/README.md
@@ -1,0 +1,20 @@
+---
+title: "Playing on Kriegspiel.org"
+slug: "playing"
+summary: "A short guide to platform-specific game behavior: hidden information, timing, guests, bots, reviews, and useful links."
+publishedAt: "2026-07-05"
+updatedAt: "2026-07-05"
+author: "Kriegspiel Team"
+tags: ["site", "game", "platform"]
+draft: false
+---
+
+Kriegspiel.org is an online referee for hidden-information chess. Choose a ruleset, create or join a game, and the server keeps the true board. Your browser receives only your side's legal view plus the public referee announcements for that ruleset. If you are new, start with the [rules index](/rules) or the [rules comparison](/rules/comparison/) before choosing a variant.
+
+Games can be human vs human, human vs bot, or bot-created lobby games. You can play from a registered account or as a guest; guest play is meant to make first games easy, while registered accounts are better for long-term identity, ratings, and history. Bots are ordinary platform players with API access, not privileged engines: they see the same player-projected game state a human would see.
+
+The default rapid clock is `25+10`. Both clocks stay paused until White completes the first real move. After that, the side to move spends time normally, and completed moves receive the increment. Kriegspiel attempts are not always completed moves: an illegal try or referee question may leave the same player on move and does not receive move increment.
+
+After the game ends, review and history pages can show more context than an active game view. The backend is the source of truth for results, timeouts, ratings, and stats, including separate overall, vs humans, and vs bots rating tracks.
+
+Useful links: [Play online](https://app.kriegspiel.org/), [Leaderboard](/leaderboard), [guest games release notes](/changelog/2026-04-29-v1-3-0), [bot guide](/blog/bot-registration-flow), and [API docs](https://api.kriegspiel.org/docs).

--- a/site/playing/README.md
+++ b/site/playing/README.md
@@ -11,10 +11,14 @@ draft: false
 
 Kriegspiel.org is an online referee for hidden-information chess. Choose a ruleset, create or join a game, and the server keeps the true board. Your browser receives only your side's legal view plus the public referee announcements for that ruleset. If you are new, start with the [rules index](/rules) or the [rules comparison](/rules/comparison/) before choosing a variant.
 
-Games can be human vs human, human vs bot, or bot-created lobby games. You can play from a registered account or as a guest; guest play is meant to make first games easy, while registered accounts are better for long-term identity, ratings, and history. Bots are ordinary platform players with API access, not privileged engines: they see the same player-projected game state a human would see.
+Games can be human vs human, human vs bot, bot vs bot, or bot-created lobby games. You can play from a registered account or as a guest; guest play is meant to make first games easy, while registered accounts are better for long-term identity, ratings, and history. Bots are ordinary platform players with API access, not privileged engines: they see the same player-projected game state a human would see.
 
 The default rapid clock is `25+10`. Both clocks stay paused until White completes the first real move. After that, the side to move spends time normally, and completed moves receive the increment. Kriegspiel attempts are not always completed moves: an illegal try or referee question may leave the same player on move and does not receive move increment.
 
-After the game ends, review and history pages can show more context than an active game view. The backend is the source of truth for results, timeouts, ratings, and stats, including separate overall, vs humans, and vs bots rating tracks.
+After the game ends, review and history pages can show more context than an active game view. The platform is the source of truth for results, timeouts, reviews, and stats.
+
+## Ratings
+
+Registered human and bot accounts each carry their own rating record. The platform tracks overall, vs humans, and vs bots ratings separately, so games against bots do not erase the human-only picture.
 
 Useful links: [Play online](https://app.kriegspiel.org/), [Leaderboard](/leaderboard), [guest games release notes](/changelog/2026-04-29-v1-3-0), [bot guide](/blog/bot-registration-flow), and [API docs](https://api.kriegspiel.org/docs).


### PR DESCRIPTION
## Summary
- Add a concise `Playing on Kriegspiel.org` site page at `/playing` covering platform behavior, timing, guests, bots, review/history, ratings, and useful links.
- Add `Playing here` to the Game footer column between `Play online` and `Leaderboard`.

## Rationale
Players need a short platform-specific guide separate from ruleset law and the About page. This gives the static site and app footer one plain entry point for practical game behavior.

## Tests
Validated together with the static-site route branch using `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-platform-game-guide`:
- `npm run content:schema:check` from `ks-home` — PASS
- Full `ks-home` validation listed in the companion static-site PR — PASS
- `git diff --check` — PASS

Exact content commit verified: `ab9c974`.

## Deployment Notes
Merge this content PR before or together with the companion `ks-home` PR, because the static-site build will require the new `site/playing` content entry.
