### PR TITLE
[codex] simplify playing guide headings

### DIFF
--- a/site/playing/README.md
+++ b/site/playing/README.md
@@ -1,7 +1,7 @@
 ---
-title: "Playing on Kriegspiel.org"
+title: "Playing Guide"
 slug: "playing"
-summary: "A short guide to platform-specific game behavior: hidden information, timing, guests, bots, reviews, and useful links."
+summary: "A short guide to playing on the platform: hidden boards, players, clock, reviews, ratings, and links."
 publishedAt: "2026-07-05"
 updatedAt: "2026-07-05"
 author: "Kriegspiel Team"
@@ -9,11 +9,19 @@ tags: ["site", "game", "platform"]
 draft: false
 ---
 
+## Hidden Board
+
 Kriegspiel.org is an online referee for hidden-information chess. Choose a ruleset, create or join a game, and the server keeps the true board. Your browser receives only your side's legal view plus the public referee announcements for that ruleset. If you are new, start with the [rules index](/rules) or the [rules comparison](/rules/comparison/) before choosing a variant.
+
+## Players
 
 Games can be human vs human, human vs bot, bot vs bot, or bot-created lobby games. You can play from a registered account or as a guest; guest play is meant to make first games easy, while registered accounts are better for long-term identity, ratings, and history. Bots are ordinary platform players with API access, not privileged engines: they see the same player-projected game state a human would see.
 
+## Clock
+
 The default rapid clock is `25+10`. Both clocks stay paused until White completes the first real move. After that, the side to move spends time normally, and completed moves receive the increment. Kriegspiel attempts are not always completed moves: an illegal try or referee question may leave the same player on move and does not receive move increment.
+
+## Review
 
 After the game ends, review and history pages can show more context than an active game view. The platform is the source of truth for results, timeouts, reviews, and stats.
 
@@ -21,4 +29,6 @@ After the game ends, review and history pages can show more context than an acti
 
 Registered human and bot accounts each carry their own rating record. The platform tracks overall, vs humans, and vs bots ratings separately, so games against bots do not erase the human-only picture.
 
-Useful links: [Play online](https://app.kriegspiel.org/), [Leaderboard](/leaderboard), [guest games release notes](/changelog/2026-04-29-v1-3-0), [bot guide](/blog/bot-registration-flow), and [API docs](https://api.kriegspiel.org/docs).
+## Links
+
+[Play online](https://app.kriegspiel.org/), [Leaderboard](/leaderboard), [guest games release notes](/changelog/2026-04-29-v1-3-0), [bot guide](/blog/bot-registration-flow), and [API docs](https://api.kriegspiel.org/docs).


### PR DESCRIPTION
## Summary
- Rename the `/playing` page title to `Playing Guide`.
- Split the page into short scan-friendly headings: Hidden Board, Players, Clock, Review, Ratings, and Links.
- Keep the same platform rules and links while making the page easier to read.

## Rationale
The live page was hard to scan because most of the content appeared as long paragraphs under one large title. Simple section titles make the guide readable at a glance.

## Validation
- `git diff --check` — PASS
- `npm run content:schema:check` from `ks-home` with `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-playing-guide-headings` — PASS
- `npm run build` from `ks-home` with the same content path — PASS
- `npm run seo:validate` — PASS
- `npm run structured-data:check` — PASS
- `npm run sitemap:generate -- --check` — PASS
- Verified generated `dist/playing/index.html` contains `Playing Guide`, `Hidden Board`, `Players`, `Clock`, `Review`, `Ratings`, and `Links`.

## Deployment Notes
Content-only change. Merge `ks-content`, then refresh/rebuild `ks-home` so `kriegspiel.org/playing` updates.
