### PR TITLE
[codex] add levels content page

### DIFF
--- a/site/levels/README.md
+++ b/site/levels/README.md
@@ -1,0 +1,36 @@
+---
+title: "Kriegspiel Levels"
+slug: "levels"
+summary: "A practical guide to Beginner, Casual, Club, Strong, Expert, Master, and Elite rating levels on Kriegspiel.org."
+publishedAt: "2026-07-05"
+updatedAt: "2026-07-05"
+author: "Kriegspiel Team"
+tags: ["site", "ratings", "levels"]
+draft: false
+---
+
+Ratings are estimates, not identities. A level describes the kind of game a player can usually handle today, and it will move as more games finish.
+
+Kriegspiel also asks for skills that normal chess ratings do not fully measure: deduction, risk control, memory, patience after illegal tries, and comfort playing without a visible enemy army. Treat these levels as a friendly map, not a title system.
+
+| Level | Rough rating | What to expect |
+|---|---:|---|
+| Beginner | 0-799 | You are learning how the hidden board changes the game. Expect missed threats, illegal tries, forgotten referee clues, and sudden tactical surprises. The main goal is to finish games, notice announcements, and get comfortable with uncertainty. |
+| Casual | 800-1199 | You understand the basic flow and can make sensible legal plans. Games still swing because of loose king safety, missed captures, or guesses made too quickly. The next step is building habits: track pawn tries, write down clues mentally, and avoid one-move hopes. |
+| Club | 1200-1599 | You can play a complete game with a plan, not just reactions. You start using absence of information as information. Mistakes still come from overconfidence: assuming a square is safe, ignoring a quiet check idea, or losing the thread after several referee calls. |
+| Strong | 1600-1999 | You are a dangerous opponent. You manage risk, preserve useful information, and often know what the opponent is trying to prove. Games are decided by calculation under uncertainty, time pressure, and whether you can keep multiple possible boards alive in your head. |
+| Expert | 2000-2199 | You reliably turn vague clues into concrete plans. You understand when to ask, when to test, when to hide information, and when to simplify. Opponents at this level punish speculative attacks and careless king moves. |
+| Master | 2200-2399 | You combine strong chess technique with strong hidden-information discipline. You can defend without seeing everything, create threats that are hard to diagnose, and convert small information advantages. Errors are usually subtle: timing, inference, or choosing the wrong uncertainty to resolve. |
+| Elite | 2400+ | You are playing near the top of the pool. You expect precise chess, careful information management, and very few free chances. Elite games often turn on small referee details, clock decisions, and long-term pressure rather than obvious tactics. |
+
+## What The Levels Are For
+
+Levels help players choose expectations before a game. A Beginner should not feel bad losing to a Club player; a Strong player should expect a Casual player to miss patterns that look obvious in hindsight.
+
+They also make progress visible. Moving from Casual to Club is often about discipline, not brilliance. Moving from Club to Strong is often about turning information into plans. Moving from Strong upward is about being accurate while never seeing the full board.
+
+## What Ratings Do Not Say
+
+A rating does not say whether someone is creative, cautious, fast, experimental, or fun to play. It also does not guarantee the result of one game. Kriegspiel has real variance because players are reasoning through incomplete information.
+
+Use the level as a starting point, then let the game tell the rest.


### PR DESCRIPTION
## Summary
- Add the new `site/levels` content page for the public levels guide.
- Describe Beginner, Casual, Club, Strong, Expert, Master, and Elite expectations with rough rating bands.
- Keep footer content unchanged.

## Rationale
This gives `kriegspiel.org/levels` a content source owned by `ks-content`, matching the existing site content model.

## Tests
- `npm run validate:frontmatter`
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:content-policy`
- `npm run build:content-index`

## Deployment Notes
Deploy with the paired `ks-home` route refresh after this content lands.
