### PR TITLE
[codex] Update English rules title

### DIFF
--- a/rules/english.md
+++ b/rules/english.md
@@ -1,16 +1,16 @@
 ---
-title: "English kriegspiel rules"
+title: "English kriegspiel rules / Gambit club rules"
 slug: "english"
 summary: "The Gambit Club English rules: three boards, umpire-controlled legality, capture-square announcements, directional checks, and the classic Any? question."
 publishedAt: "2026-04-28"
-updatedAt: "2026-05-25"
+updatedAt: "2026-07-05"
 author: "Kriegspiel Team"
 tags: ["rules", "english", "historical"]
 draft: false
 lifecycle: published
-version: "1.0.4"
-revision: "rules-english-r5"
-lastReviewedAt: "2026-05-25"
+version: "1.0.5"
+revision: "rules-english-r6"
+lastReviewedAt: "2026-07-05"
 ---
 
 These are the English rules enforced at the Gambit Club in London, as communicated by Miss E. C. Price and published in F. Dickens and G. White, *Chess in Bedfordshire*, Whitehead and Miller, Leeds, 1933.


### PR DESCRIPTION
## Summary
- Update the English rules page title to `English kriegspiel rules / Gambit club rules`.
- Bump the rules entry metadata to version `1.0.5`, revision `rules-english-r6`, reviewed/updated on `2026-07-05`.

## Rationale
The public `/rules/english` page should name the historical Gambit Club rules directly in the page title and generated metadata.

## Tests
- `npm run validate:frontmatter`
- `npm run lint:markdown`
- `npm run build:content-index`
- `npm run validate:content-policy`
- `npm run lint:links`
- From the `ks-home` validation worktree with the edited content path: `npm run content:schema:check`
- From the `ks-home` validation worktree with the edited content path: `npm run build`
- From the `ks-home` validation worktree with the edited content path: `npm run test:smoke -- --routes=/rules/english`
- Verified generated `dist/rules/english/index.html` contains `<title>Kriegspiel — English kriegspiel rules / Gambit club rules</title>` and the matching `<h1>`.

## Deployment Notes
- Content-only change.
- Refresh/redeploy `ks-home` so the static public site rebuilds from the updated `ks-content` commit.
- No backend/frontend service restart expected beyond the normal static-site deployment path.
