### PR TITLE
[codex] Use sentence case for playing guide titles

### DIFF
--- a/scripts/check-content-policy.mjs
+++ b/scripts/check-content-policy.mjs
@@ -5,6 +5,7 @@ import { entryStem, listMarkdown, parseFrontmatter } from "./lib.mjs";
 
 const ALLOWED_LIFECYCLES = new Set(["draft", "review", "published", "archived"]);
 const REQUIRED_PATHS = ["/blog/", "/changelog/", "/rules/", "/docs/", "/scripts/", "/.github/"];
+const SINGLE_CAPITAL_SITE_TITLE_STEMS = new Set(["playing"]);
 const codeownersPath = path.join(process.cwd(), ".github", "CODEOWNERS");
 const issues = [];
 
@@ -39,6 +40,13 @@ for (const doc of docs) {
     }
     if (slug && slug !== stem) {
       issues.push(`${doc.dir}/${doc.file}: site folder must match slug (${slug})`);
+    }
+    if (SINGLE_CAPITAL_SITE_TITLE_STEMS.has(stem)) {
+      for (const title of siteTitleTexts(metadata, doc.raw)) {
+        if (!hasExactlyOneCapital(title)) {
+          issues.push(`${doc.dir}/${doc.file}: title must contain exactly one capital letter: ${title}`);
+        }
+      }
     }
   }
 
@@ -83,3 +91,18 @@ if (!fs.existsSync(codeownersPath)) {
 
 assert.equal(issues.length, 0, issues.join("\n"));
 console.log(`content-policy-check: PASS (${docs.length} content docs)`);
+
+function siteTitleTexts(metadata, raw) {
+  const titles = [];
+  if (metadata.title) titles.push(String(metadata.title));
+  for (const line of raw.split(/\r?\n/)) {
+    const match = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
+    if (match) titles.push(match[2]);
+  }
+  return titles;
+}
+
+function hasExactlyOneCapital(value) {
+  const capitals = value.match(/[A-Z]/g) || [];
+  return capitals.length === 1;
+}

--- a/site/playing/README.md
+++ b/site/playing/README.md
@@ -1,5 +1,5 @@
 ---
-title: "Playing Guide"
+title: "Playing guide"
 slug: "playing"
 summary: "A short guide to playing on the platform: hidden boards, players, clock, reviews, ratings, and links."
 publishedAt: "2026-07-05"
@@ -9,7 +9,7 @@ tags: ["site", "game", "platform"]
 draft: false
 ---
 
-## Hidden Board
+## Hidden board
 
 Kriegspiel.org is an online referee for hidden-information chess. Choose a ruleset, create or join a game, and the server keeps the true board. Your browser receives only your side's legal view plus the public referee announcements for that ruleset. If you are new, start with the [rules index](/rules) or the [rules comparison](/rules/comparison/) before choosing a variant.
 


### PR DESCRIPTION
## Summary
- Change `/playing` frontmatter title from `Playing Guide` to `Playing guide`.
- Change the visible `Hidden Board` heading to `Hidden board`.
- Add a narrow content-policy regression check requiring the `/playing` page title/headings to contain exactly one capital letter.

## Rationale
The public `/playing` page should use sentence-case titles with only the initial capital letter, matching the requested style.

## Tests
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-playing-sentence-case npm run content:schema:check` from `ks-home`
- `npm run content:trigger:simulate -- --from=/home/codex/dev/kriegspiel/_worktrees/ks-content-playing-sentence-case --verify-static-regen` from `ks-home`
- Generated HTML string check for `<title>Kriegspiel — Playing guide</title>`, `<h1>Playing guide</h1>`, `<h2>Hidden board</h2>`, and absence of `Playing Guide`/`Hidden Board`.

## Deployment Notes
- Content-only change; no backend/frontend version bump.
- Deploy by refreshing the static site from `ks-content` after merge and verifying `https://kriegspiel.org/playing` shows sentence-case titles.
