### PR TITLE
Update LLM bot changelog label

### DIFF
--- a/changelog/2026-04-02-v1-1-0.md
+++ b/changelog/2026-04-02-v1-1-0.md
@@ -17,7 +17,7 @@ Highlights:
 - The app home page now shows player stats such as Elo, games played, wins, losses, and an Elo history plot.
 - Bots now carry ratings in the product surface, including lobby selection and game status.
 - Backend rules now allow bots to create and answer bot-created lobby games under explicit safety constraints.
-- Bot automation was updated so random and GPT Nano bots behave correctly under the new lobby rules.
+- Bot automation was updated so random and LLM GPT-Nano (bot) accounts behave correctly under the new lobby rules.
 - Backend and game-state handling were hardened around forced pawn-capture flows and other live-play edge cases.
 
 This release shifts the platform from simply playable to trackable, comparable, and more autonomous.


### PR DESCRIPTION
## Summary
- Update the public changelog reference from the old GPT Nano label to `LLM GPT-Nano (bot)`.

## Tests
- `npm run validate:frontmatter`
- `npm run lint:markdown`
- `npm run validate:content-policy`
- `npm run build:content-index`

## Deployment Notes
- Refresh the public static site content after merge.