### PR TITLE
Use lowercase levels page title

### DIFF
--- a/site/levels/README.md
+++ b/site/levels/README.md
@@ -1,5 +1,5 @@
 ---
-title: "Kriegspiel Levels"
+title: "Kriegspiel levels"
 slug: "levels"
 summary: "A practical tier guide for Guest, Casual, Club, Strong, Expert, Master, and Elite access on Kriegspiel.org."
 publishedAt: "2026-07-05"


### PR DESCRIPTION
## Summary
- Change the levels page title from "Kriegspiel Levels" to "Kriegspiel levels" so the visible heading and metadata use lowercase `levels`.

## Rationale
- Keeps the page title in sentence case per the requested copy fix.

## Tests
- `git diff --check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels-title-lowercase npm run content:schema:check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels-title-lowercase npm run content:source-contract:check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels-title-lowercase npm run build`
- `python3 -m html.parser dist/levels/index.html`

Verified commit: `8515639`

## Deployment
- Content-only change; deploy by refreshing the `ks-home` static site after merge.