### PR TITLE
Trim levels page to feature matrix

### DIFF
--- a/site/levels/README.md
+++ b/site/levels/README.md
@@ -3,9 +3,9 @@ title: "Kriegspiel levels"
 slug: "levels"
 summary: "A practical tier guide for Guest, Casual, Club, Strong, Expert, Master, and Elite access on Kriegspiel.org."
 publishedAt: "2026-07-05"
-updatedAt: "2026-07-05"
+updatedAt: "2026-07-06"
 author: "Kriegspiel Team"
-tags: ["site", "ratings", "bots", "levels"]
+tags: ["site", "bots", "levels"]
 draft: false
 ---
 
@@ -36,29 +36,3 @@ The table below is organized like a product tier page: features run down the lef
 One ply means one player turn. A normal full chess move is two plies: White moves once, then Black moves once.
 
 If a capped game reaches the tier limit and the language-model bot is next to move, the bot resigns instead of spending more model tokens. Simple bots remain available to guests, and human-vs-human games remain available without a language-model bot cap.
-
-## Tier rating bands
-
-Ratings are estimates, not identities. A level describes the kind of game a player can usually handle today, and it will move as more games finish.
-
-| Tier | Rough rating | What to expect |
-|---|---:|---|
-| Tier T0 Guest | Unrated | You can try Kriegspiel immediately, play human games or simple bots, and review completed games without setting up a full account. |
-| Tier T1 Casual | 0-1199 | You understand the basic flow and can make sensible legal plans. Games still swing because of loose king safety, missed captures, or guesses made too quickly. |
-| Tier T2 Club | 1200-1599 | You can play a complete game with a plan, not just reactions. You start using absence of information as information. |
-| Tier T3 Strong | 1600-1999 | You are a dangerous opponent. You manage risk, preserve useful information, and often know what the opponent is trying to prove. |
-| Tier T4 Expert | 2000-2199 | You reliably turn vague clues into concrete plans. You understand when to ask, when to test, when to hide information, and when to simplify. |
-| Tier T5 Master | 2200-2399 | You combine strong chess technique with strong hidden-information discipline. You can defend without seeing everything and convert small information advantages. |
-| Tier T6 Elite | 2400+ | You are playing near the top of the pool. Elite games often turn on small referee details, clock decisions, and long-term pressure rather than obvious tactics. |
-
-## What the levels are for
-
-Levels help players choose expectations before a game. A Casual player should not feel bad losing to a Club player; a Strong player should expect a Casual player to miss patterns that look obvious in hindsight.
-
-They also make progress visible. Moving from Casual to Club is often about discipline, not brilliance. Moving from Club to Strong is often about turning information into plans. Moving from Strong upward is about being accurate while never seeing the full board.
-
-## What ratings do not say
-
-A rating does not say whether someone is creative, cautious, fast, experimental, or fun to play. It also does not guarantee the result of one game. Kriegspiel has real variance because players are reasoning through incomplete information.
-
-Use the level as a starting point, then let the game tell the rest.


### PR DESCRIPTION
## Summary
- Remove the `Tier rating bands`, `What the levels are for`, and `What ratings do not say` sections from `/levels`.
- Remove the ratings tag from the page metadata and update the page date.

## Rationale
The levels page should focus on tier feature availability, not rating interpretation.

## Tests
- `git diff --check`
- Validated through paired `ks-home` branch build and tests against this content commit.

## Deployment notes
- Content-only change; deploy with paired `ks-home` table wrapper update.