### PR TITLE
Remove recognition rows from levels table

### DIFF
--- a/site/levels/README.md
+++ b/site/levels/README.md
@@ -29,9 +29,6 @@ The table below is organized like a product tier page: features run down the lef
 | Leaderboard eligibility | No | Yes | Yes | Yes | Yes | — | — |
 | Rating history | No | Yes | Yes | Yes | Yes | — | — |
 | Completed-game review | Yes | Yes | Yes | Yes | Yes | — | — |
-| Club-level recognition | No | No | Yes | Yes | Yes | — | — |
-| Advanced-level recognition | No | No | No | Yes | Yes | — | — |
-| Top-tier recognition | No | No | No | No | No | — | — |
 
 One ply means one player turn. A normal full chess move is two plies: White moves once, then Black moves once.
 


### PR DESCRIPTION
## Summary
- Remove the `Club-level recognition`, `Advanced-level recognition`, and `Top-tier recognition` rows from the `/levels` feature matrix.

## Rationale
Those rows were placeholder status/recognition concepts, not concrete tier features, and they made the matrix less clear.

## Tests
- `git diff --check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels-remove-recognition-rows npm run content:schema:check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels-remove-recognition-rows npm run content:source-contract:check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels-remove-recognition-rows npm run build`
- `python3 -m html.parser dist/levels/index.html`
- `npm test` in `ks-home` (61 passed)
- Rebuilt with branch content after full tests
- Verified generated `/levels` no longer contains the three recognition labels.

## Deployment notes
- Content-only change; refresh the static site with `ks-deploy home`.