### PR TITLE
[codex] Move completed review up in levels table

### DIFF
--- a/site/levels/README.md
+++ b/site/levels/README.md
@@ -19,6 +19,7 @@ The table below is organized like a product tier page: features run down the lef
 |---|---|---|---|---|---|---|---|
 | Play human games | Yes | Yes | Yes | Yes | Yes | — | — |
 | Play simple bots | Yes | Yes | Yes | Yes | Yes | — | — |
+| Completed-game review | Yes | Yes | Yes | Yes | Yes | — | — |
 | Play language-model bots | No | Yes | Yes | Yes | Yes | — | — |
 | 128-ply language-model bot games | No | Yes | Yes | Yes | Yes | — | — |
 | 256-ply language-model bot games | No | No | Yes | Yes | Yes | — | — |
@@ -28,7 +29,6 @@ The table below is organized like a product tier page: features run down the lef
 | Public player profile | No | Yes | Yes | Yes | Yes | — | — |
 | Leaderboard eligibility | No | Yes | Yes | Yes | Yes | — | — |
 | Rating history | No | Yes | Yes | Yes | Yes | — | — |
-| Completed-game review | Yes | Yes | Yes | Yes | Yes | — | — |
 
 One ply means one player turn. A normal full chess move is two plies: White moves once, then Black moves once.
 


### PR DESCRIPTION
## Summary
- Move `Completed-game review` to the third row of the `/levels` feature table.
- Keep the recognition/status rows out of the feature matrix.

## Rationale
This makes the review feature prominent while keeping tier recognition as profile/card presentation rather than a fake feature capability.

## Tests
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels-review-row-third npm run content:schema:check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels-review-row-third npm run content:source-contract:check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels-review-row-third npm run build`
- `python3 -m html.parser dist/levels/index.html`

## Deployment notes
- Content-only change. Refresh/rebuild `ks-home` after merge.