### PR TITLE
Add LLM bot tiers to levels page

### DIFF
--- a/site/levels/README.md
+++ b/site/levels/README.md
@@ -33,3 +33,14 @@ The table below is organized like a product tier page: features run down the lef
 One ply means one player turn. A normal full chess move is two plies: White moves once, then Black moves once.
 
 If a capped game reaches the tier limit and the language-model bot is next to move, the bot resigns instead of spending more model tokens. Simple bots remain available to guests, and human-vs-human games remain available without a language-model bot cap.
+
+## Available LLM bots
+
+Named language-model bot access starts at Tier T2. Higher tiers include every LLM bot from the previous tiers, so Tier T4 also includes the Tier T2 and Tier T3 bots. Tier T5 is listed as the intended Master model bucket, but Master access is not available yet.
+
+| Tier | LLM bots available at this tier |
+|---|---|
+| T2 Club | GPT-5.4 Nano; Claude Haiku 4.5; DeepSeek V4 Flash; Gemini 2.5 Flash-Lite; Llama 3.1 8B; Llama 4 Scout; Llama 4 Maverick; GPT-OSS 120B; Mistral Nemo; Mistral Small 3.2; Mistral Large 3; Gemma 3 4B; Gemma 3 27B; Gemma 4 31B; GLM 4.7 Flash; GLM 4.5 Air; Nemotron Nano; Nemotron Super; Nemotron Ultra; Kimi K2.5; Hermes 4 70B; Phi 4 |
+| T3 Strong | Includes all T2 bots, plus GPT-5.5; Claude Sonnet 5; Gemini 2.5 Flash; Qwen3.6 Flash; Qwen Plus; Kimi K2 Thinking; Hermes 3 70B |
+| T4 Expert | Includes all T2 and T3 bots, plus Claude Opus 4.8; DeepSeek V4 Pro; Gemini 3.1 Pro Preview; GLM 5.2; Kimi K2.7 Code; Hermes 4 405B |
+| T5 Master | Planned: includes all T2, T3, and T4 bots, plus GPT-5.5 Pro; Qwen3.7 Max |


### PR DESCRIPTION
## Summary
- add an Available LLM bots section to the levels content
- list T2 through planned T5 model buckets with carry-forward wording

## Rationale
The public levels page should reflect the locked LLM provider/model tier catalogue and make clear that higher tiers include previous-tier bots.

## Tests
- npm run lint:markdown -- site/levels/README.md
- npm run lint:links
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-llm-bot-tiers npm run build (from ks-home worktree)

## Deployment notes
Merge this before the ks-home refresh so the static site can rebuild from the updated content.