### PR TITLE
Remove redundant LLM bot availability row

### DIFF
--- a/site/levels/README.md
+++ b/site/levels/README.md
@@ -20,7 +20,6 @@ The table below is organized like a product tier page: features run down the lef
 | Play human games | Yes | Yes | Yes | Yes | Yes | — | — |
 | Play simple bots | Yes | Yes | Yes | Yes | Yes | — | — |
 | Completed-game review | Yes | Yes | Yes | Yes | Yes | — | — |
-| Play language-model bots | No | Yes | Yes | Yes | Yes | — | — |
 | 128-ply language-model bot games | No | Yes | Yes | Yes | Yes | — | — |
 | 256-ply language-model bot games | No | No | Yes | Yes | Yes | — | — |
 | 1024-ply language-model bot games | No | No | No | Yes | Yes | — | — |


### PR DESCRIPTION
## Summary
- remove the broad Play language-model bots row from the levels feature matrix
- keep the specific ply-limit rows and Available LLM bots section

## Rationale
The broad yes/no row duplicated the more precise tier rows and model catalogue.

## Tests
- npm run lint:markdown -- site/levels/README.md
- npm run validate:frontmatter
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-remove-llm-play-row npm run build (from ks-home worktree)

## Deployment notes
Deploy with a ks-home refresh after merge.