### PR TITLE
Update levels LLM bot tier rows

### DIFF
--- a/site/levels/README.md
+++ b/site/levels/README.md
@@ -20,10 +20,10 @@ The table below is organized like a product tier page: features run down the lef
 | Play human games | Yes | Yes | Yes | Yes | Yes | — | — |
 | Play simple bots | Yes | Yes | Yes | Yes | Yes | — | — |
 | Completed-game review | Yes | Yes | Yes | Yes | Yes | — | — |
-| 128-ply language-model bot games | No | Yes | Yes | Yes | Yes | — | — |
-| 256-ply language-model bot games | No | No | Yes | Yes | Yes | — | — |
-| 1024-ply language-model bot games | No | No | No | Yes | Yes | — | — |
-| Unlimited language-model bot games | No | No | No | No | Yes | — | — |
+| Play T2 bots | No | No | Yes | Yes | Yes | Yes | Yes |
+| Play T3 bots | No | No | No | Yes | Yes | Yes | Yes |
+| Play T4 bots | No | No | No | No | Yes | Yes | Yes |
+| Play T5 bots | No | No | No | No | No | Yes | Yes |
 | Persistent player name | No | Yes | Yes | Yes | Yes | — | — |
 | Public player profile | No | Yes | Yes | Yes | Yes | — | — |
 | Leaderboard eligibility | No | Yes | Yes | Yes | Yes | — | — |
@@ -35,11 +35,11 @@ If a capped game reaches the tier limit and the language-model bot is next to mo
 
 ## Available LLM bots
 
-Named language-model bot access starts at Tier T2. Higher tiers include every LLM bot from the previous tiers, so Tier T4 also includes the Tier T2 and Tier T3 bots. Tier T5 is listed as the intended Master model bucket, but Master access is not available yet.
+Named language-model bot access starts at Tier T2. Higher tiers include every LLM bot from the previous tiers, so Tier T4 also includes the Tier T2 and Tier T3 bots. Tier T5 is listed as the intended Master model bucket, but Master access is not available yet. Profile links point to live bot accounts.
 
 | Tier | LLM bots available at this tier |
 |---|---|
-| T2 Club | GPT-5.4 Nano; Claude Haiku 4.5; DeepSeek V4 Flash; Gemini 2.5 Flash-Lite; Llama 3.1 8B; Llama 4 Scout; Llama 4 Maverick; GPT-OSS 120B; Mistral Nemo; Mistral Small 3.2; Mistral Large 3; Gemma 3 4B; Gemma 3 27B; Gemma 4 31B; GLM 4.7 Flash; GLM 4.5 Air; Nemotron Nano; Nemotron Super; Nemotron Ultra; Kimi K2.5; Hermes 4 70B; Phi 4 |
-| T3 Strong | Includes all T2 bots, plus GPT-5.5; Claude Sonnet 5; Gemini 2.5 Flash; Qwen3.6 Flash; Qwen Plus; Kimi K2 Thinking; Hermes 3 70B |
-| T4 Expert | Includes all T2 and T3 bots, plus Claude Opus 4.8; DeepSeek V4 Pro; Gemini 3.1 Pro Preview; GLM 5.2; Kimi K2.7 Code; Hermes 4 405B |
+| T2 Club | [OpenAI GPTNano](https://app.kriegspiel.org/user/llm_gptnano); [OpenAI GPT-OSS](https://app.kriegspiel.org/user/llm_gptoss120b); [Claude Haiku 4.5](https://app.kriegspiel.org/user/llm_haiku); [DeepSeek V4 Flash](https://app.kriegspiel.org/user/llm_deepseekv4_flash); [Gemini 2.5 Flash-Lite](https://app.kriegspiel.org/user/llm_gemini25_lite); [Gemini 3.1 Flash-Lite](https://app.kriegspiel.org/user/llm_gemini31_lite); [Llama 3.1 8B](https://app.kriegspiel.org/user/llm_llama31_8b); Llama 4 Scout; Llama 4 Maverick; Mistral Nemo; Mistral Small 3.2; Mistral Large 3; Gemma 3 4B; Gemma 3 27B; Gemma 4 31B; GLM 4.7 Flash; GLM 4.5 Air; Nemotron Nano; Nemotron Super; Nemotron Ultra; Kimi K2.5; Hermes 4 70B; Phi 4 |
+| T3 Strong | Includes all T2 bots, plus GPT-5.5; Claude Sonnet 5; Gemini 2.5 Flash; [Qwen3.6 Flash](https://app.kriegspiel.org/user/llm_qwen36_flash); Qwen Plus; Kimi K2 Thinking; Hermes 3 70B |
+| T4 Expert | Includes all T2 and T3 bots, plus Claude Opus 4.8; [DeepSeek V4 Pro](https://app.kriegspiel.org/user/bot_deepseekv4_pro); Gemini 3.1 Pro Preview; GLM 5.2; Kimi K2.7 Code; Hermes 4 405B |
 | T5 Master | Planned: includes all T2, T3, and T4 bots, plus GPT-5.5 Pro; Qwen3.7 Max |


### PR DESCRIPTION
## Summary
- rename the `/levels` LLM feature rows to `Play T2 bots`, `Play T3 bots`, `Play T4 bots`, and `Play T5 bots`
- mark each bot tier as available from its own public tier through later tiers
- add live app profile links for deployed LLM bot accounts in the Available LLM bots table

## Rationale
The public tier page should describe named LLM bot access by subscription bot tier instead of old ply-limit labels, and it should let readers jump directly to live bot profiles.

## Tests
- `npm run lint:markdown -- site/levels/README.md`
- `npm run validate:frontmatter`
- `npm run lint:links`
- rendered through `ks-home` with `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-play-tier-bot-links npm run build`

## Deployment Notes
Requires a `ks-home` refresh/redeploy after merge so `kriegspiel.org/levels` picks up the content change.
