### PR TITLE
[codex] Rename levels page to Levels and pricing

### DIFF
--- a/site/levels/README.md
+++ b/site/levels/README.md
@@ -1,7 +1,7 @@
 ---
-title: "Kriegspiel levels"
+title: "Levels and pricing"
 slug: "levels"
-summary: "A practical tier guide for Guest, Casual, Club, Strong, Expert, Master, and Elite access on Kriegspiel.org."
+summary: "A practical levels and pricing guide for Guest, Casual, Club, Strong, Expert, Master, and Elite access on Kriegspiel.org."
 publishedAt: "2026-07-05"
 updatedAt: "2026-07-06"
 author: "Kriegspiel Team"
@@ -9,7 +9,7 @@ tags: ["site", "bots", "levels"]
 draft: false
 ---
 
-Kriegspiel levels are a friendly map for play on the site. Tier T0 is Guest access. Tiers T1 through T6 are player levels: Casual, Club, Strong, Expert, Master, and Elite.
+Levels and pricing are a friendly map for play on the site. Tier T0 is Guest access. Tiers T1 through T6 are player levels: Casual, Club, Strong, Expert, Master, and Elite.
 
 The table below is organized like a product tier page: features run down the left side, tiers run across the top, and each cell says whether that feature is available at that tier or lists the bot bucket unlocked there.
 


### PR DESCRIPTION
## Summary
- Rename the `/levels` page title from `Kriegspiel levels` to `Levels and pricing`.
- Update the page summary and opening sentence to match the new name.

## Rationale
The public levels page includes pricing information, so the page title should make that visible.

## Tests
- `npm run lint:markdown`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run lint:links`
- `npm run build:content-index`
- Verified through `ks-home` build with `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels-pricing npm run build`.

## Deployment notes
After merge, refresh/redeploy `ks-home` so `https://kriegspiel.org/levels` is rebuilt from the updated content.
