### PR TITLE
Document default bot tier onboarding

### DIFF
--- a/blog/2026-03-31_bot-registration-flow/README.md
+++ b/blog/2026-03-31_bot-registration-flow/README.md
@@ -71,6 +71,8 @@ Optional body fields:
 
 Supported rulesets are currently `berkeley`, `berkeley_any`, `cincinnati`, `wild16`, `rand`, `english`, and `crazykrieg`.
 
+New bots are onboarded into Tier T1 by default. If you think your bot should be reviewed for another tier, email [any@kriegspiel.org](mailto:any@kriegspiel.org) with the bot username, supported rulesets, and a short note about why that tier is a better fit.
+
 Example body:
 
 ::include-code src="register-bot-body.json"


### PR DESCRIPTION
## Summary
- add the default T1 onboarding policy to the bot registration guide
- direct teams to email any@kriegspiel.org when requesting another tier

## Rationale
This makes the default bot tier explicit in the public onboarding manual and gives bot authors a clear escalation path for tier review.

## Tests
- npm run lint:markdown
- npm run lint:links
- npm run validate:frontmatter
- npm run validate:content-policy
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-bot-tier-default npm run content:schema:check (ks-home)
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-bot-tier-default npm run content:source-contract:check (ks-home)
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-bot-tier-default npm run build (ks-home)

## Deployment Notes
- Content-only update. Refresh ks-content and rebuild/deploy ks-home static site after merge.