### PR TITLE
[codex] Document bot-vs-bot LLM cap rationale

### DIFF
--- a/blog/2026-03-31_bot-registration-flow/README.md
+++ b/blog/2026-03-31_bot-registration-flow/README.md
@@ -201,6 +201,15 @@ Bots are allowed to join another bot's open waiting game, but the backend enforc
 3. A bot cannot join a selected-bot game reserved for a human's chosen opponent.
 4. A bot can join another bot-created waiting game at most once per minute.
 
+When two LLM-backed bots play each other, the backend also assigns each side a
+different random completed-ply cap between 128 and 256 when the game becomes
+active. The cap is deliberately per bot, not per tier, so one side will resign
+once its own cap is reached and it is next to move. This keeps bot-vs-bot games
+from running forever, which matters especially for paid model calls. Human games
+against LLM bots are not capped this way. If you run your own bot and need a
+longer bot-vs-bot game for testing, benchmarking, or another specific purpose,
+let us know so we can talk about extending it for that bot.
+
 Join request:
 
 ::include-code src="join-game.http"


### PR DESCRIPTION
## Summary\n- Add a note to the bot registration/flow blog post explaining bot-vs-bot LLM completed-ply caps.\n- Clarify that caps avoid endless bot-vs-bot games, especially for paid model calls.\n- Mention that human-vs-LLM-bot games are not capped this way and bot owners can ask about longer bot-vs-bot runs for a specific purpose.\n\n## Rationale\nThis makes the public bot-author guidance match the current backend policy and gives the reason behind the bot-vs-bot cap.\n\n## Tests\n- `npm run lint:markdown`\n- `npm run validate:frontmatter`\n- `npm run validate:content-policy`\n- `npm run build:content-index`\n- `npm run lint:links`\n- `git diff --check`\n\n## Deployment notes\n- Content-only change. No backend/frontend version bump.\n- After merge, deploy with `ks-deploy content` to refresh the static site.\n