### PR TITLE
Add subscription billing terms and privacy wording

### DIFF
--- a/site/privacy/README.md
+++ b/site/privacy/README.md
@@ -3,7 +3,7 @@ title: "Privacy Policy"
 slug: "privacy"
 summary: "A brief plain-English summary of what data Kriegspiel collects and why."
 publishedAt: "2026-03-28T00:00:00.000Z"
-updatedAt: "2026-04-29T00:00:00.000Z"
+updatedAt: "2026-07-11T00:00:00.000Z"
 author: "Kriegspiel Team"
 tags: ["policy", "privacy"]
 draft: false
@@ -15,10 +15,13 @@ We collect a few basic kinds of data to run Kriegspiel:
 
 - **Account data** you provide, such as your email address and profile details.
 - **Gameplay and activity data** such as games, moves, results, ratings, and related account activity.
+- **Billing data** needed for subscriptions, such as checkout status, subscription status, invoices, payment status, and limited billing contact details.
 - **Support communications** you send us.
 - **Basic technical and log data** needed to operate, secure, and debug the service.
 
 We use this data to run accounts and games, keep the service secure, prevent abuse, diagnose problems, respond to support and privacy requests, and improve the service.
+
+Payments are processed by Stripe. We do not store full card numbers; Stripe handles payment details under its own terms and privacy policy, and sends us the billing records needed to manage access, invoices, refunds, disputes, fraud prevention, and support.
 
 We do **not** sell personal data. We may share data with service providers that help us run Kriegspiel, or when required by law.
 

--- a/site/terms/README.md
+++ b/site/terms/README.md
@@ -3,7 +3,7 @@ title: "Terms of Use"
 slug: "terms"
 summary: "A brief plain-English summary of the basic rules for using Kriegspiel."
 publishedAt: "2026-03-28T00:00:00.000Z"
-updatedAt: "2026-04-29T00:00:00.000Z"
+updatedAt: "2026-07-11T00:00:00.000Z"
 author: "Kriegspiel Team"
 tags: ["policy", "terms"]
 draft: false
@@ -14,6 +14,10 @@ By accessing or using the Kriegspiel website, including browsing public pages, r
 You agree to use Kriegspiel responsibly and not abuse, disrupt, or attack the service.
 
 You are responsible for your account and for what happens through it.
+
+Paid subscriptions, if offered, renew automatically until canceled through Manage billing. Prices, billing intervals, and renewal details are shown at checkout; cancellation stops future renewals but does not retroactively refund the current paid period.
+
+Payments are final once the account has played at least one game after the purchase or renewal, except where required by law. If no game was played, email **billing@kriegspiel.org** and we may review refunds case by case.
 
 We may suspend or remove accounts, content, or access if we see abuse, cheating, harassment, illegal use, or other behavior that harms the service or the community.
 


### PR DESCRIPTION
## Summary
- Add short subscription renewal/cancellation/refund language to Terms.
- Add short Stripe/payment-data language to Privacy.
- Update policy page updatedAt dates.

## Rationale
The app now supports paid subscriptions, so public policy pages should briefly explain renewal, cancellation, refund handling, and payment processing.

## Tests
- npm run validate:frontmatter
- npm run lint:markdown
- npm run lint:links
- npm run validate:content-policy
- npm run build:content-index
- ks-home with KS_CONTENT_PATH pointing at this branch: npm run content:schema:check
- ks-home with KS_CONTENT_PATH pointing at this branch: npm run build

## Deployment notes
- Content-only change.
- After merge, deploy with ks-deploy content to pull ks-content and refresh kriegspiel.org static pages.