### PR TITLE
Structure terms page sections

### DIFF
--- a/site/terms/README.md
+++ b/site/terms/README.md
@@ -9,22 +9,38 @@ tags: ["policy", "terms"]
 draft: false
 ---
 
+### Access
+
 By accessing or using the Kriegspiel website, including browsing public pages, registering, logging in, or playing as a guest, you agree to these Terms of Use and acknowledge the [Privacy Policy](/privacy).
+
+### Conduct
 
 You agree to use Kriegspiel responsibly and not abuse, disrupt, or attack the service.
 
+### Accounts
+
 You are responsible for your account and for what happens through it.
+
+### Billing
 
 Paid subscriptions, if offered, renew automatically until canceled through Manage billing. Prices, billing intervals, and renewal details are shown at checkout; cancellation stops future renewals but does not retroactively refund the current paid period.
 
 Payments are final once the account has played at least one game after the purchase or renewal, except where required by law. If no game was played, email **billing@kriegspiel.org** and we may review refunds case by case.
 
+### Moderation
+
 We may suspend or remove accounts, content, or access if we see abuse, cheating, harassment, illegal use, or other behavior that harms the service or the community.
+
+### Availability
 
 Kriegspiel is provided **as is**. It may change, break, or be interrupted. We may update, limit, or remove features at any time.
 
 Games, content, ratings, messages, and even accounts may occasionally be lost, rolled back, unavailable, or removed. Please do not rely on the service as if it were guaranteed permanent storage.
 
+### Updates
+
 We may update these terms from time to time. If you keep using Kriegspiel after changes are posted here, that means you accept the revised terms.
+
+### Contact
 
 Questions about these terms: **terms@kriegspiel.org**


### PR DESCRIPTION
## Summary
- add small Markdown section subtitles to the Terms of Use page
- keep the existing terms wording unchanged

## Rationale
The Terms page was a flat sequence of paragraphs. Small subtitles make it easier to scan without making the page feel heavy.

## Tests
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-terms-small-sections npm run content:schema:check` in `ks-home`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-terms-small-sections npm run content:source-contract:check` in `ks-home`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-terms-small-sections npm run build` in `ks-home`
- `npm run test:smoke -- --routes=/terms,/privacy` in `ks-home`

## Deployment notes
Content-only change. After merge, deploy with `ks-deploy content` to refresh `kriegspiel.org/terms`.
