### PR TITLE
Remove playing guide links section

### DIFF
--- a/site/playing/README.md
+++ b/site/playing/README.md
@@ -1,7 +1,7 @@
 ---
 title: "Playing guide"
 slug: "playing"
-summary: "A short guide to playing on the platform: hidden boards, players, clock, reviews, ratings, and links."
+summary: "A short guide to playing on the platform: hidden boards, players, clock, reviews, and ratings."
 publishedAt: "2026-07-05"
 updatedAt: "2026-07-05"
 author: "Kriegspiel Team"
@@ -28,7 +28,3 @@ After the game ends, review and history pages can show more context than an acti
 ## Ratings
 
 Registered human and bot accounts each carry their own rating record. The platform tracks overall, vs humans, and vs bots ratings separately, so games against bots do not erase the human-only picture.
-
-## Links
-
-[Play online](https://app.kriegspiel.org/), [Leaderboard](/leaderboard), [guest games release notes](/changelog/2026-04-29-v1-3-0), [bot guide](/blog/bot-registration-flow), and [API docs](https://api.kriegspiel.org/docs).


### PR DESCRIPTION
## Summary
- remove the standalone “Links” section from the public playing guide
- trim the page summary so it no longer advertises links

## Rationale
The playing guide already has site navigation and footer links, and the reviewed page should end after the ratings content instead of repeating a link roundup.

## Tests
ks-content:
- `npm ci`
- `npm run lint:markdown`
- `npm run lint:links`
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run build:content-index`

ks-home, with `KS_CONTENT_PATH` pointed at this content worktree:
- `npm run content:schema:check`
- `npm run content:source-contract:check`
- `npm run build`
- `npm run routes:validate`
- `npm run test:smoke -- --routes=/playing`
- `npm run test -- --runInBand --watch=false`

## Deployment notes
- After merge, deploy with `ks-deploy content` so the public static site refreshes from `ks-content`.