### PR TITLE
Add subscription to footer game links

### DIFF
--- a/site/footer/README.md
+++ b/site/footer/README.md
@@ -3,7 +3,7 @@ title: "Footer"
 slug: "footer"
 summary: "Canonical footer content and link grouping for kriegspiel.org."
 publishedAt: "2026-03-29"
-updatedAt: "2026-07-05"
+updatedAt: "2026-07-11"
 author: "Kriegspiel Team"
 tags: ["site", "footer", "navigation"]
 draft: false
@@ -11,6 +11,7 @@ draft: false
 # Game
 - [Play online](https://app.kriegspiel.org/)
 - [Playing guide](/playing)
+- [Subscription](/subscription)
 - [Leaderboard](/leaderboard)
 
 # Rules


### PR DESCRIPTION
Summary
- Add Subscription as the third link in the footer Game group.
- Refresh the footer content updatedAt date.

Rationale
- The public site footer is content-owned, so production needs this canonical footer entry in ks-content.

Tests
- Validated via ks-home with KS_CONTENT_PATH pointing at this branch:
  - npm test
  - npm run content:schema:check
  - npm run routes:validate
  - npm run build

Deployment notes
- Deploy with the paired ks-home navigation/version PR so the header renderer and content footer ship together.