### PR TITLE
Add 1.4.0 changelog note

### DIFF
--- a/changelog/2026-07-12-v1-4-0.md
+++ b/changelog/2026-07-12-v1-4-0.md
@@ -1,0 +1,30 @@
+---
+title: Version 1.4.0 LLM bot playground
+slug: 2026-07-12-v1-4-0
+summary: LLM bot tiers, subscriptions, usage reports, stronger history tools, and a more scalable app.
+publishedAt: 2026-07-12
+updatedAt: 2026-07-12
+author: Kriegspiel Team
+tags: [changelog, release, llms, bots, subscriptions, reports, performance]
+draft: false
+lifecycle: published
+version: 1.4.0
+---
+Version `1.4.0` makes the expensive-bot era official.
+
+The main change is that LLM-backed opponents are no longer a hidden experiment. They are now part of the product: visible in the lobby, organized by access tier, linked from profiles and subscription pages, checked for provider availability, measured for cost, and ready for the kind of "what happens if these models play Kriegspiel?" fun that requires a little billing courage.
+
+Major improvements since `1.3.0`:
+
+- LLM bots became a full platform feature, with tiered T2/T3/T4 catalog entries, model availability reports, direct profile links, bot challenge flows, and upgrade prompts when a player picks a stronger bot than their level allows.
+- Subscription support is now present across the app and public site, including a signed-in subscription page, billing and checkout flows, guest-account blockers, a public subscription redirect, and clearer tier matrices for model-bot access.
+- The private Bots' matrix grew from a static snapshot into a live operator report with period filters, row and column bot selectors, outcome filters, matchup links, totals, end conditions, and per-recorded-game token and spend averages.
+- Bot usage reporting now records model calls, input/cache/output tokens, and estimated spend on games when bots provide usage data, so expensive matches can be analyzed instead of merely admired from a safe distance.
+- Human and bot histories became much more scalable: sorting, filters, exact opponent links, all-human/all-bot groups, larger page sizes, profile metrics, leaderboard filters, and bot profile stats now lean on backend queries instead of frontend guesswork.
+- Live play is calmer and more current, with server-sent game updates, better timeout/tab-resume refreshes, completed-game redirects to review, copyable game codes and share links, more stable board layouts, and friendlier lobby feedback.
+- Reviews and ruleset details improved across the board, including combined review loading, stronger replay controls, clearer result reasons, English en-passant announcements, RAND stalemate wins, double-check messages, and CrazyKrieg reserve/drop handling.
+- Guest accounts matured after the guest release: guests can convert to regular accounts, keep longer-lived sessions, appear correctly in public metadata, and show up in more useful operator reports.
+- Backend operations tightened up with prefix-free API docs for bot developers, self-serve bot registration, private tech reports, safer API ingress, HTTPS/HSTS behavior at the app edge, first-party campaign attribution, and performance-oriented caches and archive queries.
+- The public website gained the playing guide, subscription routing, RSS/Atom update feeds, sitemap generation, more polished problem-board interactions, and continued rules/reference cleanup.
+
+In short: `1.4.0` is the model-bot playground release. Kriegspiel now has the rails for playing, limiting, measuring, and enjoying LLM opponents without pretending the fun is free.


### PR DESCRIPTION
## Summary

- Add `changelog/2026-07-12-v1-4-0.md` with the public 1.4.0 release note.
- Summarize the release in the same style as previous public changenotes, with LLM bots and expensive-bot fun as the central story.

## Rationale

The public changelog needs a single readable 1.4.0 narrative that ties together model bots, subscriptions, usage reports, history/report scaling, live/review polish, and website/RSS updates.

## Tests

- `npm run validate:frontmatter` at commit `9d6f233`.
- `npm run lint:markdown` at commit `9d6f233`.

## Deployment notes

- Content-only change, but it should be deployed together with the `ks-home` refresh so the static changelog and RSS/Atom feeds include the new entry.
