### PR TITLE
Mention GPT-5.5 Pro reasoning in changelog

### DIFF
--- a/changelog/2026-07-12-v1-4-0.md
+++ b/changelog/2026-07-12-v1-4-0.md
@@ -17,6 +17,7 @@ The main change is that LLM-backed opponents are no longer a hidden experiment. 
 Major improvements since `1.3.0`:
 
 - LLM bots became a full platform feature, with tiered T2/T3/T4 catalog entries, model availability reports, direct profile links, bot challenge flows, and upgrade prompts when a player picks a stronger bot than their level allows.
+- The upper LLM catalog now includes the new T5 OpenAI bots, including GPT-5.5 Pro with default reasoning set to `medium`.
 - Subscription support is now present across the app and public site, including a signed-in subscription page, billing and checkout flows, guest-account blockers, a public subscription redirect, and clearer tier matrices for model-bot access.
 - The private Bots' matrix grew from a static snapshot into a live operator report with period filters, row and column bot selectors, outcome filters, matchup links, totals, end conditions, and per-recorded-game token and spend averages.
 - Bot usage reporting now records model calls, input/cache/output tokens, and estimated spend on games when bots provide usage data, so expensive matches can be analyzed instead of merely admired from a safe distance.


### PR DESCRIPTION
## Summary
- Adds an explicit 1.4.0 changelog bullet naming GPT-5.5 Pro and its default `medium` reasoning.

## Rationale
The public changelog described the LLM bot rollout broadly, but did not surface the GPT-5.5 Pro reasoning default now shown in the app and platform docs.

## Validation
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run lint:markdown`
- `npm run lint:links`
- `git diff --check`

## Deployment Notes
Content-only change consumed by `ks-home`; refresh/redeploy `ks-home` after merge.
