### PR TITLE
Mention GPT-5.5 Pro reasoning in changelog summary

### DIFF
--- a/changelog/2026-07-12-v1-4-0.md
+++ b/changelog/2026-07-12-v1-4-0.md
@@ -1,7 +1,7 @@
 ---
 title: Version 1.4.0 LLM bot playground
 slug: 2026-07-12-v1-4-0
-summary: LLM bot tiers, subscriptions, usage reports, stronger history tools, and a more scalable app.
+summary: LLM bot tiers, including GPT-5.5 Pro with medium reasoning, subscriptions, usage reports, and stronger history tools.
 publishedAt: 2026-07-12
 updatedAt: 2026-07-12
 author: Kriegspiel Team


### PR DESCRIPTION
## Summary
- Updates the public 1.4.0 changelog summary so the `/changelog` index itself mentions GPT-5.5 Pro with medium reasoning.

## Rationale
The changelog detail body already included the GPT-5.5 Pro reasoning note, but the changelog index renders the frontmatter summary and still did not show it.

## Validation
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run lint:markdown`
- `npm run lint:links`
- `git diff --check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-gpt55-pro-changelog npm run content:schema:check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-gpt55-pro-changelog npm run build`
- confirmed built `dist/changelog/index.html` contains `GPT-5.5 Pro with medium reasoning`

## Deployment Notes
Content-only change; redeploy `ks-home` after merge so the public changelog index refreshes.
