### PR TITLE
Rollback public GPT-5.5 Pro reasoning changelog

### DIFF
--- a/changelog/2026-07-12-v1-4-0.md
+++ b/changelog/2026-07-12-v1-4-0.md
@@ -1,7 +1,7 @@
 ---
 title: Version 1.4.0 LLM bot playground
 slug: 2026-07-12-v1-4-0
-summary: LLM bot tiers, including GPT-5.5 Pro with medium reasoning, subscriptions, usage reports, and stronger history tools.
+summary: LLM bot tiers, subscriptions, usage reports, stronger history tools, and a more scalable app.
 publishedAt: 2026-07-12
 updatedAt: 2026-07-12
 author: Kriegspiel Team
@@ -17,7 +17,6 @@ The main change is that LLM-backed opponents are no longer a hidden experiment. 
 Major improvements since `1.3.0`:
 
 - LLM bots became a full platform feature, with tiered T2/T3/T4 catalog entries, model availability reports, direct profile links, bot challenge flows, and upgrade prompts when a player picks a stronger bot than their level allows.
-- The upper LLM catalog now includes the new T5 OpenAI bots, including GPT-5.5 Pro with default reasoning set to `medium`.
 - Subscription support is now present across the app and public site, including a signed-in subscription page, billing and checkout flows, guest-account blockers, a public subscription redirect, and clearer tier matrices for model-bot access.
 - The private Bots' matrix grew from a static snapshot into a live operator report with period filters, row and column bot selectors, outcome filters, matchup links, totals, end conditions, and per-recorded-game token and spend averages.
 - Bot usage reporting now records model calls, input/cache/output tokens, and estimated spend on games when bots provide usage data, so expensive matches can be analyzed instead of merely admired from a safe distance.


### PR DESCRIPTION
## Summary
- Removes the GPT-5.5 Pro reasoning note from the public 1.4.0 changelog body.
- Restores the 1.4.0 changelog index summary to the prior wording.

## Rationale
The GPT-5.5 Pro reasoning detail belongs in the platform financial docs, not the public changelog.

## Validation
- `npm run validate:frontmatter`
- `npm run validate:content-policy`
- `npm run lint:markdown`
- `npm run lint:links`
- `git diff --cached --check`

## Deployment Notes
Content-only rollback consumed by `ks-home`; redeploy `ks-home` after merge.
